### PR TITLE
feat(registers): Hardware Update registers and RWU access type

### DIFF
--- a/REGBLKREADME.md
+++ b/REGBLKREADME.md
@@ -27,6 +27,12 @@ bsub -q be -Is /home/runzhe.liu/tssv2redzone/tssvRegBlk /home/runzhe.liu/tssv2re
 ```
 其中,16为指定的总线地址位宽，可修改。如像Run the flow 1中不指定，则默认为12。
 
+### Run the flow 3
+支持生成Hardware Update类型寄存器。对输入文件的修改参考/sv-examples/gold/Hard_Update2.0.csv
+```bash
+bsub -q be -Is /home/runzhe.liu/tssv2redzone/tssvRegBlk /home/runzhe.liu/tssv2redzone/sv-examples/gold/Hard_Update2.0.csv
+```
+
 ### FAQ
 
 1.由于需要Node和gcc环境，如果不采用提交作业的方法，

--- a/out/src/core/Base.js
+++ b/out/src/core/Base.js
@@ -449,7 +449,6 @@ export class Module {
                     qSig.type = 'logic';
                     break;
                 case 'reg':
-                // case 'output reg':
                 case 'logic':
                     break;
                 default:

--- a/sv-examples/gold/AIGC_DEMO_Reg_pkg.sv
+++ b/sv-examples/gold/AIGC_DEMO_Reg_pkg.sv
@@ -1,0 +1,43 @@
+package AIGC_DEMO_reg_pkg;
+
+// =============================================================================
+// Register bit field definition
+// =============================================================================
+
+typedef struct packed {
+  logic [31: 0] ID;
+} UNIT_ID_t;
+
+typedef struct packed {
+  logic ctrl3;
+  logic [6:0] res_1;
+  logic [15: 0] ctrl2;
+  logic [4:0] res_0;
+  logic ctrl1;
+  logic [1: 0] ctrl0;
+} CTRL_t;
+
+typedef struct packed {
+  logic [6:0] res_1;
+  logic m2_clear;
+  logic [15:0] res_0;
+  logic [3: 0] m1_clr;
+  logic [3: 0] m0_clr;
+} CFG0_t;
+
+typedef struct packed {
+  logic [7: 0] bus1_prdy;
+  logic [7: 0] bus1_pvld;
+  logic [7: 0] bus0_prdy;
+  logic [7: 0] bus0_pvld;
+} DEBUG_0_t;
+
+typedef struct packed {
+  logic [31: 0] status;
+} DEBUG_1_t;
+
+typedef struct packed {
+  logic [31: 0] dummy_debug;
+} DUMMY_DEBUG_t;
+
+endpackage : AIGC_DEMO_reg_pkg

--- a/sv-examples/gold/AIGC_DEMO_reg.sv
+++ b/sv-examples/gold/AIGC_DEMO_reg.sv
@@ -1,0 +1,243 @@
+import AIGC_DEMO_reg_pkg::*;
+
+// =============================================================================
+// Register module
+// =============================================================================
+
+
+
+
+/* verilator lint_off WIDTH */
+module AIGC_DEMO_reg
+(
+input logic  clk,
+input logic  rst_b,
+input logic [11:0] paddr,
+input logic [31:0] pwdata,
+output logic [31:0] prdata,
+input logic  psel,
+input logic  penable,
+input logic  pwrite,
+output logic  pready,
+output reg  pslverr,
+input logic [31:0] cfg_unit_id,
+output logic [31:0] cfg_ctrl,
+output logic [31:0] cfg_cfg0,
+input logic [31:0] cfg_debug_0,
+input logic [31:0] cfg_debug_1_0,
+input logic [31:0] cfg_debug_1_1,
+input logic [31:0] cfg_debug_1_2,
+input logic [31:0] cfg_debug_1_3,
+input logic [31:0] cfg_debug_1_4,
+input logic [31:0] cfg_debug_1_5,
+input logic [31:0] cfg_debug_1_6,
+input logic [31:0] cfg_debug_1_7,
+output logic [31:0] cfg_dummy_debug
+);
+
+logic  reg_rd;
+logic  reg_wr;
+logic [11:0] reg_addr;
+logic [31:0] reg_rdata;
+logic [31:0] reg_wdata;
+logic [31:0] next_rdata;
+logic  in_range;
+logic  slverr;
+logic  dec_unit_id;
+UNIT_ID_t reg_unit_id;
+logic  dec_ctrl;
+CTRL_t reg_ctrl;
+logic  ctrl_we;
+logic  dec_cfg0;
+CFG0_t reg_cfg0;
+logic  cfg0_sc;
+logic  cfg0_we;
+logic  dec_debug_0;
+DEBUG_0_t reg_debug_0;
+logic  dec_debug_1_0;
+DEBUG_1_t reg_debug_1_0;
+logic  dec_debug_1_1;
+DEBUG_1_t reg_debug_1_1;
+logic  dec_debug_1_2;
+DEBUG_1_t reg_debug_1_2;
+logic  dec_debug_1_3;
+DEBUG_1_t reg_debug_1_3;
+logic  dec_debug_1_4;
+DEBUG_1_t reg_debug_1_4;
+logic  dec_debug_1_5;
+DEBUG_1_t reg_debug_1_5;
+logic  dec_debug_1_6;
+DEBUG_1_t reg_debug_1_6;
+logic  dec_debug_1_7;
+DEBUG_1_t reg_debug_1_7;
+logic  dec_dummy_debug;
+DUMMY_DEBUG_t reg_dummy_debug;
+logic  dummy_debug_we;
+
+// apb interface
+assign prdata = reg_rdata;
+assign reg_wr = psel && penable && pwrite;
+assign reg_rd = psel && !penable && !pwrite;
+assign pready = 1'b1;
+assign slverr = psel && !in_range;
+assign reg_addr = paddr;
+assign reg_wdata = pwdata;
+assign dec_unit_id = (reg_addr == 12'h000) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_unit_id = cfg_unit_id;
+assign dec_ctrl = (reg_addr == 12'h004) ? 1'd1 : 1'd0;
+assign ctrl_we = reg_wr && dec_ctrl;
+// non-RO: output
+assign cfg_ctrl = reg_ctrl;
+assign dec_cfg0 = (reg_addr == 12'h00C) ? 1'd1 : 1'd0;
+assign cfg0_we = reg_wr && dec_cfg0;
+// non-RO: output
+assign cfg_cfg0 = reg_cfg0;
+assign dec_debug_0 = (reg_addr == 12'h400) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_0 = cfg_debug_0;
+assign dec_debug_1_0 = (reg_addr == 12'h404) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_0 = cfg_debug_1_0;
+assign dec_debug_1_1 = (reg_addr == 12'h408) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_1 = cfg_debug_1_1;
+assign dec_debug_1_2 = (reg_addr == 12'h40C) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_2 = cfg_debug_1_2;
+assign dec_debug_1_3 = (reg_addr == 12'h410) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_3 = cfg_debug_1_3;
+assign dec_debug_1_4 = (reg_addr == 12'h414) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_4 = cfg_debug_1_4;
+assign dec_debug_1_5 = (reg_addr == 12'h418) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_5 = cfg_debug_1_5;
+assign dec_debug_1_6 = (reg_addr == 12'h41C) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_6 = cfg_debug_1_6;
+assign dec_debug_1_7 = (reg_addr == 12'h420) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1_7 = cfg_debug_1_7;
+assign dec_dummy_debug = (reg_addr == 12'hFFC) ? 1'd1 : 1'd0;
+assign dummy_debug_we = reg_wr && dec_dummy_debug;
+// non-RO: output
+assign cfg_dummy_debug = reg_dummy_debug;
+assign in_range = |{dec_unit_id,
+dec_ctrl,
+dec_cfg0,
+dec_debug_0,
+dec_debug_1_0,
+dec_debug_1_1,
+dec_debug_1_2,
+dec_debug_1_3,
+dec_debug_1_4,
+dec_debug_1_5,
+dec_debug_1_6,
+dec_debug_1_7,
+dec_dummy_debug};
+// Read data mux
+assign next_rdata =
+( {32{dec_unit_id}} & reg_unit_id ) |
+( {32{dec_ctrl}} & reg_ctrl ) |
+( {32{dec_cfg0}} & 32'h0 ) |
+( {32{dec_debug_0}} & reg_debug_0 ) |
+( {32{dec_debug_1_0}} & reg_debug_1_0 ) |
+( {32{dec_debug_1_1}} & reg_debug_1_1 ) |
+( {32{dec_debug_1_2}} & reg_debug_1_2 ) |
+( {32{dec_debug_1_3}} & reg_debug_1_3 ) |
+( {32{dec_debug_1_4}} & reg_debug_1_4 ) |
+( {32{dec_debug_1_5}} & reg_debug_1_5 ) |
+( {32{dec_debug_1_6}} & reg_debug_1_6 ) |
+( {32{dec_debug_1_7}} & reg_debug_1_7 ) |
+( {32{dec_dummy_debug}} & reg_dummy_debug );
+
+
+
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+pslverr <= 1'h0;
+end
+else
+begin
+pslverr <= slverr;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_ctrl <= 32'h10001;
+end
+else if(ctrl_we)
+begin
+reg_ctrl <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_cfg0 <= 32'h0;
+end
+else if(cfg0_we)
+begin
+reg_cfg0 <= reg_wdata;
+end
+else if(cfg0_sc)
+begin
+reg_cfg0 <= 32'h0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+cfg0_sc <= 1'h0;
+end
+else if(cfg0_we)
+begin
+cfg0_sc <= 1'b1;
+end
+else if(cfg0_sc)
+begin
+cfg0_sc <= 1'b0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_dummy_debug <= 32'h0;
+end
+else if(dummy_debug_we)
+begin
+reg_dummy_debug <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_rdata <= 32'h0;
+end
+else if(reg_rd)
+begin
+reg_rdata <= next_rdata;
+end
+
+
+
+endmodule
+/* verilator lint_on WIDTH */
+ : AIGC_DEMO_reg

--- a/sv-examples/gold/APB_int_gold/tb_intAIGCAPB4reg.sv
+++ b/sv-examples/gold/APB_int_gold/tb_intAIGCAPB4reg.sv
@@ -1,0 +1,336 @@
+
+
+
+
+interface APB4_12_32;
+
+logic  PCLK;
+logic  PRESETn;
+logic [11:0] PADDR;
+logic  PSELx;
+logic  PENABLE;
+logic  PWRITE;
+logic [31:0] PRDATA;
+logic [31:0] PWDATA;
+logic [2:0] PPROT;
+logic [3:0] PSTRB;
+logic  PREADY;
+logic  PSLVERR;
+logic  PCLKEN;
+
+
+modport outward (
+input PCLK,
+input PRESETn,
+output PADDR,
+output PSELx,
+output PENABLE,
+output PWRITE,
+input PRDATA,
+output PWDATA,
+output PPROT,
+output PSTRB,
+input PREADY,
+input PSLVERR,
+input PCLKEN
+);
+
+modport inward (
+input PCLK,
+input PRESETn,
+input PADDR,
+input PSELx,
+input PENABLE,
+input PWRITE,
+output PRDATA,
+input PWDATA,
+input PPROT,
+input PSTRB,
+output PREADY,
+output PSLVERR,
+input PCLKEN
+);
+
+
+endinterface
+
+
+
+
+/* verilator lint_off WIDTH */
+module AIGC_DEMO_reg
+(
+input logic  clk,
+input logic  rst_b,
+input logic [31:0] cfg_unit_id,
+output logic [31:0] cfg_ctrl,
+output logic [31:0] cfg_cfg0,
+input logic [31:0] cfg_debug_0,
+input logic [31:0] cfg_debug_1,
+output logic [31:0] cfg_dummy_debug,
+APB4_12_32.inward regs
+);
+
+logic  reg_rd;
+logic  reg_wr;
+logic [11:0] reg_addr;
+logic [31:0] reg_rdata;
+logic [31:0] reg_wdata;
+logic [31:0] next_rdata;
+logic  in_range;
+logic  slverr;
+logic  dec_unit_id;
+logic [31:0] reg_unit_id;
+logic  dec_ctrl;
+logic [31:0] reg_ctrl;
+logic  ctrl_re;
+logic  ctrl_we;
+logic  dec_cfg0;
+logic [31:0] reg_cfg0;
+logic  cfg0_sc;
+logic  cfg0_we;
+logic  dec_debug_0;
+logic [31:0] reg_debug_0;
+logic  dec_debug_1;
+logic [31:0] reg_debug_1;
+logic  dec_dummy_debug;
+logic [31:0] reg_dummy_debug;
+logic  dummy_debug_re;
+logic  dummy_debug_we;
+
+// apb interface
+always_comb
+begin
+reg_wr = regs.PSELx && regs.PENABLE && regs.PWRITE;
+reg_rd = regs.PSELx && !regs.PENABLE && !regs.PWRITE;
+reg_addr = regs.PADDR;
+reg_wdata = regs.PWDATA;
+regs.PRDATA = reg_rdata;
+
+regs.PREADY = 1'b1;
+end
+
+assign slverr = regs.PSELx && !in_range;
+assign dec_unit_id = (reg_addr == 12'h000) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_unit_id = cfg_unit_id;
+assign dec_ctrl = (reg_addr == 12'h004) ? 1'd1 : 1'd0;
+assign ctrl_re = reg_rd && dec_ctrl;
+assign ctrl_we = reg_wr && dec_ctrl;
+// non-RO: output
+assign cfg_ctrl = reg_ctrl;
+assign dec_cfg0 = (reg_addr == 12'h00C) ? 1'd1 : 1'd0;
+assign cfg0_we = reg_wr && dec_cfg0;
+// non-RO: output
+assign cfg_cfg0 = reg_cfg0;
+assign dec_debug_0 = (reg_addr == 12'h400) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_0 = cfg_debug_0;
+assign dec_debug_1 = (reg_addr == 12'h404) ? 1'd1 : 1'd0;
+// RO reg: input
+assign reg_debug_1 = cfg_debug_1;
+assign dec_dummy_debug = (reg_addr == 12'hFFC) ? 1'd1 : 1'd0;
+assign dummy_debug_re = reg_rd && dec_dummy_debug;
+assign dummy_debug_we = reg_wr && dec_dummy_debug;
+// non-RO: output
+assign cfg_dummy_debug = reg_dummy_debug;
+// address decode
+assign in_range = |{dec_unit_id,
+dec_ctrl,
+dec_cfg0,
+dec_debug_0,
+dec_debug_1,
+dec_dummy_debug};
+// Read data mux
+assign next_rdata =
+( {32{dec_unit_id}} & reg_unit_id ) |
+( {32{dec_ctrl}} & reg_ctrl ) |
+( {32{dec_cfg0}} & 32'h0 ) |
+( {32{dec_debug_0}} & reg_debug_0 ) |
+( {32{dec_debug_1}} & reg_debug_1 ) |
+( {32{dec_dummy_debug}} & reg_dummy_debug );
+
+
+
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+regs.PSLVERR <= undefined'h0;
+end
+else
+begin
+regs.PSLVERR <= slverr;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_ctrl <= 32'h10001;
+end
+else if(ctrl_we)
+begin
+reg_ctrl <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_cfg0 <= 32'h0;
+end
+else if(cfg0_we)
+begin
+reg_cfg0 <= reg_wdata;
+end
+else if(cfg0_sc)
+begin
+reg_cfg0 <= 32'h0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+cfg0_sc <= 1'h0;
+end
+else if(cfg0_we)
+begin
+cfg0_sc <= 1'b1;
+end
+else if(cfg0_sc)
+begin
+cfg0_sc <= 1'b0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_dummy_debug <= 32'h0;
+end
+else if(dummy_debug_we)
+begin
+reg_dummy_debug <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_rdata <= 32'h0;
+end
+else if(reg_rd)
+begin
+reg_rdata <= next_rdata;
+end
+
+
+
+endmodule
+/* verilator lint_on WIDTH */
+
+
+/* verilator lint_off WIDTH */
+module tb_testRegBlock
+(
+input logic  clk,
+input logic  rst_b
+);
+
+APB4_12_32 regs();
+logic [31:0] cfg_unit_id;
+logic [31:0] cfg_ctrl;
+logic [31:0] cfg_cfg0;
+logic [31:0] cfg_debug_0;
+logic [31:0] cfg_debug_1;
+logic [31:0] cfg_dummy_debug;
+
+
+logic [15:0] count;
+
+always @(posedge clk or negedge rst_b) begin
+if (!rst_b) begin
+count <= 'd0;
+end else begin
+count <= count + 1'b1;
+
+case (count)
+'d0: begin
+regs.PADDR <= 32'h00000000;
+regs.PWDATA <= 32'h12345678;
+regs.PWRITE <= 1;
+regs.PENABLE <= 1;
+end
+'d1: begin
+regs.PWRITE <= 0;
+regs.PWRITE <= 0;
+regs.PENABLE <= 1;
+end
+'d2: begin
+regs.PWRITE <= 0;
+regs.PENABLE <= 0;
+end
+'d3: begin
+regs.PADDR <= 32'h00000008;
+regs.PWDATA <= 32'h87654321;
+regs.PWRITE <= 1;
+end
+'d4: begin
+regs.PWRITE <= 0;
+regs.PENABLE <= 1;
+end
+'d5: begin
+regs.PWRITE <= 0;
+regs.PENABLE <= 0;
+end
+'d6: begin
+regs.PADDR <= 32'h00000020;
+regs.PWDATA <= 32'hAABBCCDD;
+regs.PWRITE <= 1;
+end
+'d7: begin
+regs.PWRITE <= 0;
+regs.PENABLE <= 1;
+end
+'d8: begin
+regs.PWRITE <= 0;
+regs.PENABLE <= 0;
+end
+'d9: begin
+// End of test
+$finish;
+end
+default: ;
+endcase
+end
+end
+
+
+
+AIGC_DEMO_reg dut
+(
+.clk(clk),
+.rst_b(rst_b),
+.cfg_unit_id(cfg_unit_id),
+.cfg_ctrl(cfg_ctrl),
+.cfg_cfg0(cfg_cfg0),
+.cfg_debug_0(cfg_debug_0),
+.cfg_debug_1(cfg_debug_1),
+.cfg_dummy_debug(cfg_dummy_debug),
+.regs(regs)
+);
+
+
+
+
+endmodule
+/* verilator lint_on WIDTH */

--- a/sv-examples/gold/APB_int_gold/tb_testRegBlock1.0.sv
+++ b/sv-examples/gold/APB_int_gold/tb_testRegBlock1.0.sv
@@ -1,0 +1,472 @@
+
+            
+    
+            
+    
+            
+    /* verilator lint_off WIDTH */        
+    module ram_32x32 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   input logic [31:0] addr,
+   input logic  we,
+   input logic  re,
+   input logic [31:0] wdata,
+   output logic [31:0] rdata,
+   output logic  ready
+       );
+    
+    
+    
+    
+  logic [31:0] mem [0:31];
+
+  always_ff @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+          rdata <= 32'd0;
+          ready <= 1'b0;
+      end else if (we) begin
+          mem[addr] <= wdata;
+          ready <= 1'b1;
+      end else if (re) begin
+          rdata <= mem[addr];
+          ready <= 1'b1;
+      end else begin
+          ready <= 1'b0;
+      end
+  end
+
+
+    
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+            
+    
+            
+    /* verilator lint_off WIDTH */        
+    module rom_32x32 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   input logic [31:0] addr,
+   input logic  re,
+   output logic [31:0] rdata,
+   output logic  ready
+       );
+    
+    
+    
+    
+  logic [31:0] mem [0:31];
+
+  initial begin
+      // Initialize ROM with some values
+      mem[0] = 32'h00000001;
+      mem[1] = 32'h00000002;
+      mem[2] = 32'h00000003;
+      mem[3] = 32'h00000004;
+      // ...
+  end
+
+  always_ff @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+          rdata <= 32'd0;
+          ready <= 1'b0;
+      end else if (re) begin
+          rdata <= mem[addr];
+          ready <= 1'b1;
+      end else begin
+          ready <= 1'b0;
+      end
+  end
+
+
+    
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+    
+interface memory_32_32;
+
+   logic [31:0] ADDR;
+   logic [31:0] DATA_WR;
+   logic [31:0] DATA_RD;
+   logic  RE;
+   logic  WE;
+   logic  READY;
+   logic [3:0] WSTRB;
+
+
+    modport outward (
+      input ADDR,
+      output DATA_WR,
+      input DATA_RD,
+      output WE,
+      output RE,
+      input READY,
+      output WSTRB
+    );           
+
+    modport inward (
+      output ADDR,
+      input DATA_WR,
+      output DATA_RD,
+      input WE,
+      input RE,
+      output READY,
+      input WSTRB
+    );           
+
+
+endinterface
+        
+        
+    
+            
+    /* verilator lint_off WIDTH */        
+    module testRegBlock 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   output logic [31:0] REG0,
+   output logic signed [15:0] REG1,
+   output logic [15:0] REG2_field0,
+   output logic [15:0] REG2_field1,
+   output logic [31:0] MEM0_rdata,
+   output logic  MEM0_re,
+   output logic  MEM0_we,
+   output logic [31:0] MEM0_wdata,
+   output logic [31:0] MEM0_wstrb,
+   output logic  MEM0_ready,
+   output logic [31:0] MEM1_rdata,
+   output logic  MEM1_re,
+   output logic  MEM1_ready,
+   memory_32_32.inward regs
+       );
+    
+       logic  REG0_matchSig;
+   logic [3:0] REG0_wstrb;
+   logic  REG0_RE;
+   logic  REG0_WE;
+   logic [31:0] REG0_d;
+   logic  REG1_matchSig;
+   logic  REG1_RE;
+   logic  REG2_matchSig;
+   logic [3:0] REG2_wstrb;
+   logic  REG2_RE;
+   logic  REG2_WE;
+   logic  MEM0_matchSig;
+   logic  MEM0_Nmatch;
+   logic [31:0] MEM0_ADDR;
+   logic  MEM0_RE;
+   logic  MEM0_WE;
+   logic  MEM1_matchSig;
+   logic  MEM1_RE;
+   logic [31:0] MEM1_ADDR;
+    
+    assign REG0_matchSig = regs.ADDR == 0;
+assign REG0_RE = REG0_matchSig && regs.RE;
+assign REG0_WE = REG0_matchSig && regs.WE;
+assign REG0_wstrb = regs.WSTRB;
+assign REG0_d = regs.DATA_WR & REG0_wstrb;
+assign REG1_matchSig = regs.ADDR == 4;
+assign REG1_RE = REG1_matchSig && regs.RE;
+assign REG2_matchSig = regs.ADDR == 8;
+assign REG2_RE = REG2_matchSig && regs.RE;
+assign REG2_WE = REG2_matchSig && regs.WE;
+assign REG2_wstrb = regs.WSTRB;
+assign MEM0_matchSig = (regs.ADDR >= 32) && (regs.ADDR <= (63));
+assign MEM0_Nmatch = regs.ADDR & 4'b1100 == 32;
+assign MEM0_RE = MEM0_matchSig && regs.RE;
+assign MEM0_WE = MEM0_matchSig && regs.WE;
+assign MEM0_ADDR = regs.ADDR;
+assign MEM1_matchSig = (regs.ADDR >= 64) && (regs.ADDR <= (95));
+assign MEM1_RE = MEM1_matchSig && regs.RE;
+assign MEM1_ADDR = regs.ADDR;
+
+  always @(regs.ADDR or regs.RE)
+    if(regs.RE == 1) begin
+      /* verilator lint_off CASEX */
+      casex (regs.ADDR)
+        8'b00000000: begin
+            regs.DATA_RD <= REG0;
+            regs.READY <= 1'b1;
+        end
+     8'b00000100: begin
+            regs.DATA_RD <= REG1;
+            regs.READY <= 1'b1;
+        end
+     8'b00001000: begin
+            regs.DATA_RD <= {REG2_field1, REG2_field0};
+            regs.READY <= 1'b1;
+        end
+     8'b001XXXXX: begin
+            regs.DATA_RD <= MEM0_wdata;
+            regs.READY <= MEM0_ready;
+        end
+     8'b01XXXXXX: begin
+            regs.DATA_RD <= MEM1_rdata;
+            regs.READY <= MEM1_ready;
+        end
+      default: regs.DATA_RD <= 0;
+    endcase
+  end
+
+    
+
+    
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG0 <= 32'h0;
+  end
+  else if(REG0_WE)
+  begin
+  REG0 <= regs.DATA_WR;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG2_field0 <= 16'h10;
+  end
+  else if(REG2_WE && REG2_wstrb)
+  begin
+  REG2_field0 <= regs.DATA_WR[15:0];
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG2_field1 <= 16'h20;
+  end
+  else if(REG2_WE && REG2_wstrb)
+  begin
+  REG2_field1 <= regs.DATA_WR[31:16];
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_ready <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_ready <= regs.READY;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_wdata <= 32'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_wdata <= regs.DATA_WR;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_re <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_re <= MEM0_RE;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_we <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_we <= MEM0_WE;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_wstrb <= 32'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_wstrb <= 1;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM1_ready <= 1'h0;
+  end
+  else if(regs.WE)
+  begin
+  MEM1_ready <= regs.READY;
+  end
+  
+  
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+            
+    /* verilator lint_off WIDTH */        
+    module tb_testRegBlock 
+       (
+       input logic  clk,
+   input logic  rst_b
+       );
+    
+       memory_32_32 regs();
+   logic [31:0] addr;
+   logic  we;
+   logic  re;
+   logic [31:0] wdata;
+   logic [31:0] rdata;
+   logic  ready;
+   logic [31:0] REG0;
+   logic signed [15:0] REG1;
+   logic [15:0] REG2_field0;
+   logic [15:0] REG2_field1;
+   logic [31:0] MEM0_rdata;
+   logic  MEM0_re;
+   logic  MEM0_we;
+   logic [31:0] MEM0_wdata;
+   logic [31:0] MEM0_wstrb;
+   logic  MEM0_ready;
+   logic [31:0] MEM1_rdata;
+   logic  MEM1_re;
+   logic  MEM1_ready;
+    
+    
+    logic [15:0] count;
+
+    always @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+         count <= 'd0;
+      end else begin
+         count <= count + 1'b1;
+
+         case (count)
+            'd0: begin
+               regs.ADDR <= 32'h00000000;
+               regs.DATA_WR <= 32'h12345678;
+               regs.WE <= 1;
+            end
+            'd1: begin
+               regs.WE <= 0;
+               regs.RE <= 1;
+            end
+            'd2: begin
+               regs.RE <= 0;
+            end
+            'd3: begin
+               regs.ADDR <= 32'h00000008;
+               regs.DATA_WR <= 32'h87654321;
+               regs.WE <= 1;
+            end
+            'd4: begin
+               regs.WE <= 0;
+               regs.RE <= 1;
+            end
+            'd5: begin
+               regs.RE <= 0;
+            end
+            'd6: begin
+               regs.ADDR <= 32'h00000020;
+               regs.DATA_WR <= 32'hAABBCCDD;
+               regs.WE <= 1;
+            end
+            'd7: begin
+               regs.WE <= 0;
+               MEM0_rdata <= 32'hAABBCCDD;
+               regs.RE <= 1;
+            end
+            'd8: begin
+               regs.RE <= 0;
+            end
+            'd9: begin
+               // End of test
+               $finish;
+            end
+            default: ;
+         endcase
+      end
+    end
+
+
+    
+      ram_32x32 ram_inst
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .addr(addr),
+        .we(we),
+        .re(re),
+        .wdata(wdata),
+        .rdata(rdata),
+        .ready(ready)
+      );
+  
+      rom_32x32 rom_inst
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .addr(addr),
+        .re(re),
+        .rdata(rdata),
+        .ready(ready)
+      );
+  
+      testRegBlock dut
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .REG0(REG0),
+        .REG1(REG1),
+        .REG2_field0(REG2_field0),
+        .REG2_field1(REG2_field1),
+        .MEM0_rdata(MEM0_rdata),
+        .MEM0_re(MEM0_re),
+        .MEM0_we(MEM0_we),
+        .MEM0_wdata(MEM0_wdata),
+        .MEM0_wstrb(MEM0_wstrb),
+        .MEM0_ready(MEM0_ready),
+        .MEM1_rdata(MEM1_rdata),
+        .MEM1_re(MEM1_re),
+        .MEM1_ready(MEM1_ready),
+        .regs(regs)
+      );
+  
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    

--- a/sv-examples/gold/Hard_Update2.0.csv
+++ b/sv-examples/gold/Hard_Update2.0.csv
@@ -1,0 +1,6 @@
+Block Name,Block Offset,Register Name,Register Offset,Access Mode(RW/RO/WO/W1C/W1T/W1S),Repeat,Register Description,Field,Bits,Access Type(RW/RO/WO/W1C/W1T/W1S),Reset Value,HDL Path,Field Description,Write Out
+Update,0x0000F000,,,,,,,,,,,,,
+,,WPTR,0x0,RWU,,,,,,,,,
+,,,,,,,wptr,31:0,RWU,0x0,,,,
+,,FETCH_RPTR,0x4,RWU,,,,,,,,,
+,,,,,,,fetch_rptr,31:0,RWU,0x0,,,,

--- a/sv-examples/reg_convert/AIGC_DEMO_Reg.sv
+++ b/sv-examples/reg_convert/AIGC_DEMO_Reg.sv
@@ -1,0 +1,229 @@
+import AIGC_DEMO_Reg_pkg::*;
+
+// =============================================================================
+// Generated Register Block 1.0
+// =============================================================================
+
+// Commit ID: 5d881a42678bd22a450b3e43987eb208f7e70cf4
+
+
+
+module AIGC_DEMO_Reg
+(
+input logic  clk,
+input logic  rst_b,
+input logic [11:0] paddr,
+input logic [31:0] pwdata,
+output logic [31:0] prdata,
+input logic  psel,
+input logic  penable,
+input logic  pwrite,
+output logic  pready,
+output reg  pslverr,
+input logic [31:0] cfg_unit_id,
+output logic [31:0] cfg_ctrl,
+output logic [31:0] cfg_cfg0,
+input logic [31:0] cfg_debug_0,
+input logic [31:0] cfg_debug_1_0,
+input logic [31:0] cfg_debug_1_1,
+input logic [31:0] cfg_debug_1_2,
+input logic [31:0] cfg_debug_1_3,
+input logic [31:0] cfg_debug_1_4,
+input logic [31:0] cfg_debug_1_5,
+input logic [31:0] cfg_debug_1_6,
+input logic [31:0] cfg_debug_1_7,
+output logic [31:0] cfg_dummy_debug
+);
+
+logic  reg_rd;
+logic  reg_wr;
+logic [11:0] reg_addr;
+logic [31:0] reg_rdata;
+logic [31:0] reg_wdata;
+logic [31:0] next_rdata;
+logic  in_range;
+logic  slverr;
+logic  dec_unit_id;
+UNIT_ID_t reg_unit_id;
+logic  dec_ctrl;
+CTRL_t reg_ctrl;
+logic  ctrl_we;
+logic  dec_cfg0;
+CFG0_t reg_cfg0;
+logic  cfg0_sc;
+logic  cfg0_we;
+logic  dec_debug_0;
+DEBUG_0_t reg_debug_0;
+logic  dec_debug_1_0;
+DEBUG_1_t reg_debug_1_0;
+logic  dec_debug_1_1;
+DEBUG_1_t reg_debug_1_1;
+logic  dec_debug_1_2;
+DEBUG_1_t reg_debug_1_2;
+logic  dec_debug_1_3;
+DEBUG_1_t reg_debug_1_3;
+logic  dec_debug_1_4;
+DEBUG_1_t reg_debug_1_4;
+logic  dec_debug_1_5;
+DEBUG_1_t reg_debug_1_5;
+logic  dec_debug_1_6;
+DEBUG_1_t reg_debug_1_6;
+logic  dec_debug_1_7;
+DEBUG_1_t reg_debug_1_7;
+logic  dec_dummy_debug;
+DUMMY_DEBUG_t reg_dummy_debug;
+logic  dummy_debug_we;
+
+// apb interface
+assign reg_wr = psel && penable && pwrite;
+assign reg_rd = psel && !penable && !pwrite;
+assign reg_addr = paddr;
+assign reg_wdata = pwdata;
+assign prdata = reg_rdata;
+assign pready = 1'b1;
+assign slverr = psel && !in_range;
+assign dec_unit_id = (reg_addr == 12'h000) ? 1'd1 : 1'd0;
+assign reg_unit_id = cfg_unit_id;
+assign dec_ctrl = (reg_addr == 12'h004) ? 1'd1 : 1'd0;
+assign ctrl_we = reg_wr && dec_ctrl;
+assign cfg_ctrl = reg_ctrl;
+assign dec_cfg0 = (reg_addr == 12'h00C) ? 1'd1 : 1'd0;
+assign cfg0_we = reg_wr && dec_cfg0;
+assign cfg_cfg0 = reg_cfg0;
+assign dec_debug_0 = (reg_addr == 12'h400) ? 1'd1 : 1'd0;
+assign reg_debug_0 = cfg_debug_0;
+assign dec_debug_1_0 = (reg_addr == 12'h404) ? 1'd1 : 1'd0;
+assign reg_debug_1_0 = cfg_debug_1_0;
+assign dec_debug_1_1 = (reg_addr == 12'h408) ? 1'd1 : 1'd0;
+assign reg_debug_1_1 = cfg_debug_1_1;
+assign dec_debug_1_2 = (reg_addr == 12'h40C) ? 1'd1 : 1'd0;
+assign reg_debug_1_2 = cfg_debug_1_2;
+assign dec_debug_1_3 = (reg_addr == 12'h410) ? 1'd1 : 1'd0;
+assign reg_debug_1_3 = cfg_debug_1_3;
+assign dec_debug_1_4 = (reg_addr == 12'h414) ? 1'd1 : 1'd0;
+assign reg_debug_1_4 = cfg_debug_1_4;
+assign dec_debug_1_5 = (reg_addr == 12'h418) ? 1'd1 : 1'd0;
+assign reg_debug_1_5 = cfg_debug_1_5;
+assign dec_debug_1_6 = (reg_addr == 12'h41C) ? 1'd1 : 1'd0;
+assign reg_debug_1_6 = cfg_debug_1_6;
+assign dec_debug_1_7 = (reg_addr == 12'h420) ? 1'd1 : 1'd0;
+assign reg_debug_1_7 = cfg_debug_1_7;
+assign dec_dummy_debug = (reg_addr == 12'hFFC) ? 1'd1 : 1'd0;
+assign dummy_debug_we = reg_wr && dec_dummy_debug;
+assign cfg_dummy_debug = reg_dummy_debug;
+assign in_range = |{dec_unit_id,
+dec_ctrl,
+dec_cfg0,
+dec_debug_0,
+dec_debug_1_0,
+dec_debug_1_1,
+dec_debug_1_2,
+dec_debug_1_3,
+dec_debug_1_4,
+dec_debug_1_5,
+dec_debug_1_6,
+dec_debug_1_7,
+dec_dummy_debug};
+// Read data mux
+assign next_rdata =
+( {32{dec_unit_id}} & reg_unit_id ) |
+( {32{dec_ctrl}} & reg_ctrl ) |
+( {32{dec_cfg0}} & 32'h0 ) |
+( {32{dec_debug_0}} & reg_debug_0 ) |
+( {32{dec_debug_1_0}} & reg_debug_1_0 ) |
+( {32{dec_debug_1_1}} & reg_debug_1_1 ) |
+( {32{dec_debug_1_2}} & reg_debug_1_2 ) |
+( {32{dec_debug_1_3}} & reg_debug_1_3 ) |
+( {32{dec_debug_1_4}} & reg_debug_1_4 ) |
+( {32{dec_debug_1_5}} & reg_debug_1_5 ) |
+( {32{dec_debug_1_6}} & reg_debug_1_6 ) |
+( {32{dec_debug_1_7}} & reg_debug_1_7 ) |
+( {32{dec_dummy_debug}} & reg_dummy_debug );
+
+
+
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+pslverr <= 1'h0;
+end
+else
+begin
+pslverr <= slverr;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_ctrl <= 32'h10001;
+end
+else if(ctrl_we)
+begin
+reg_ctrl <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_cfg0 <= 32'h0;
+end
+else if(cfg0_we)
+begin
+reg_cfg0 <= reg_wdata;
+end
+else if(cfg0_sc)
+begin
+reg_cfg0 <= 32'b0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+cfg0_sc <= 1'h0;
+end
+else if(cfg0_we)
+begin
+cfg0_sc <= 1'b1;
+end
+else if(cfg0_sc)
+begin
+cfg0_sc <= 1'b0;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_dummy_debug <= 32'h0;
+end
+else if(dummy_debug_we)
+begin
+reg_dummy_debug <= reg_wdata;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_rdata <= 32'h0;
+end
+else if(reg_rd)
+begin
+reg_rdata <= next_rdata;
+end
+
+
+
+endmodule
+ : AIGC_DEMO_Reg

--- a/sv-examples/reg_convert/Hard_Update2.0_reg.sv
+++ b/sv-examples/reg_convert/Hard_Update2.0_reg.sv
@@ -1,0 +1,132 @@
+import AIGC_DEMO_reg_pkg::*;
+
+// =============================================================================
+// Register module
+// =============================================================================
+
+
+
+
+/* verilator lint_off WIDTH */
+module AIGC_DEMO_reg
+(
+input logic  clk,
+input logic  rst_b,
+input logic [11:0] paddr,
+input logic [31:0] pwdata,
+output logic [31:0] prdata,
+input logic  psel,
+input logic  penable,
+input logic  pwrite,
+output logic  pready,
+output reg  pslverr,
+output logic [31:0] cfg_wptr,
+input logic  wptr_update,
+input logic [31:0] wptr_update_value,
+output logic [31:0] cfg_fetch_rptr,
+input logic  fetch_rptr_update,
+input logic [31:0] fetch_rptr_update_value
+);
+
+logic  reg_rd;
+logic  reg_wr;
+logic [11:0] reg_addr;
+logic [31:0] reg_rdata;
+logic [31:0] reg_wdata;
+logic [31:0] next_rdata;
+logic  in_range;
+logic  slverr;
+logic  dec_wptr;
+WPTR_t reg_wptr;
+logic  wptr_we;
+logic  dec_fetch_rptr;
+FETCH_RPTR_t reg_fetch_rptr;
+logic  fetch_rptr_we;
+
+// apb interface
+assign prdata = reg_rdata;
+assign reg_wr = psel && penable && pwrite;
+assign reg_rd = psel && !penable && !pwrite;
+assign pready = 1'b1;
+assign slverr = psel && !in_range;
+assign reg_addr = paddr;
+assign reg_wdata = pwdata;
+assign dec_wptr = (reg_addr == 12'hF000) ? 1'd1 : 1'd0;
+assign wptr_we = reg_wr && dec_wptr;
+// non-RO: output
+assign cfg_wptr = reg_wptr;
+assign dec_fetch_rptr = (reg_addr == 12'hF004) ? 1'd1 : 1'd0;
+assign fetch_rptr_we = reg_wr && dec_fetch_rptr;
+// non-RO: output
+assign cfg_fetch_rptr = reg_fetch_rptr;
+assign in_range = |{dec_wptr,
+dec_fetch_rptr};
+// Read data mux
+assign next_rdata =
+( {32{dec_wptr}} & reg_wptr ) |
+( {32{dec_fetch_rptr}} & reg_fetch_rptr );
+
+
+
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+pslverr <= 1'h0;
+end
+else
+begin
+pslverr <= slverr;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_wptr <= 32'h0;
+end
+else if(wptr_we)
+begin
+reg_wptr <= reg_wdata;
+end
+else if(wptr_update)
+begin
+reg_wptr <= wptr_update_value;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_fetch_rptr <= 32'h0;
+end
+else if(fetch_rptr_we)
+begin
+reg_fetch_rptr <= reg_wdata;
+end
+else if(fetch_rptr_update)
+begin
+reg_fetch_rptr <= fetch_rptr_update_value;
+end
+
+
+always_ff @( posedge clk  or negedge rst_b )
+
+if(!rst_b)
+begin
+reg_rdata <= 32'h0;
+end
+else if(reg_rd)
+begin
+reg_rdata <= next_rdata;
+end
+
+
+
+endmodule
+/* verilator lint_on WIDTH */
+ : AIGC_DEMO_reg

--- a/sv-examples/reg_convert/Hard_Update2.0_reg_pkg.sv
+++ b/sv-examples/reg_convert/Hard_Update2.0_reg_pkg.sv
@@ -1,0 +1,15 @@
+package AIGC_DEMO_reg_pkg;
+
+// =============================================================================
+// Register bit field definition
+// =============================================================================
+
+typedef struct packed {
+  logic [31: 0] wptr;
+} WPTR_t;
+
+typedef struct packed {
+  logic [31: 0] fetch_rptr;
+} FETCH_RPTR_t;
+
+endpackage : AIGC_DEMO_reg_pkg

--- a/sv-examples/tb_testRegBlock.sv
+++ b/sv-examples/tb_testRegBlock.sv
@@ -1,0 +1,472 @@
+
+            
+    
+            
+    
+            
+    /* verilator lint_off WIDTH */        
+    module ram_32x32 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   input logic [31:0] addr,
+   input logic  we,
+   input logic  re,
+   input logic [31:0] wdata,
+   output logic [31:0] rdata,
+   output logic  ready
+       );
+    
+    
+    
+    
+  logic [31:0] mem [0:31];
+
+  always_ff @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+          rdata <= 32'd0;
+          ready <= 1'b0;
+      end else if (we) begin
+          mem[addr] <= wdata;
+          ready <= 1'b1;
+      end else if (re) begin
+          rdata <= mem[addr];
+          ready <= 1'b1;
+      end else begin
+          ready <= 1'b0;
+      end
+  end
+
+
+    
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+            
+    
+            
+    /* verilator lint_off WIDTH */        
+    module rom_32x32 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   input logic [31:0] addr,
+   input logic  re,
+   output logic [31:0] rdata,
+   output logic  ready
+       );
+    
+    
+    
+    
+  logic [31:0] mem [0:31];
+
+  initial begin
+      // Initialize ROM with some values
+      mem[0] = 32'h00000001;
+      mem[1] = 32'h00000002;
+      mem[2] = 32'h00000003;
+      mem[3] = 32'h00000004;
+      // ...
+  end
+
+  always_ff @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+          rdata <= 32'd0;
+          ready <= 1'b0;
+      end else if (re) begin
+          rdata <= mem[addr];
+          ready <= 1'b1;
+      end else begin
+          ready <= 1'b0;
+      end
+  end
+
+
+    
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+    
+interface memory_32_32;
+
+   logic [31:0] ADDR;
+   logic [31:0] DATA_WR;
+   logic [31:0] DATA_RD;
+   logic  RE;
+   logic  WE;
+   logic  READY;
+   logic [3:0] WSTRB;
+
+
+    modport outward (
+      input ADDR,
+      output DATA_WR,
+      input DATA_RD,
+      output WE,
+      output RE,
+      input READY,
+      output WSTRB
+    );           
+
+    modport inward (
+      output ADDR,
+      input DATA_WR,
+      output DATA_RD,
+      input WE,
+      input RE,
+      output READY,
+      input WSTRB
+    );           
+
+
+endinterface
+        
+        
+    
+            
+    /* verilator lint_off WIDTH */        
+    module testRegBlock 
+       (
+       input logic  clk,
+   input logic  rst_b,
+   output logic [31:0] REG0,
+   output logic signed [15:0] REG1,
+   output logic [15:0] REG2_field0,
+   output logic [15:0] REG2_field1,
+   output logic [31:0] MEM0_rdata,
+   output logic  MEM0_re,
+   output logic  MEM0_we,
+   output logic [31:0] MEM0_wdata,
+   output logic [31:0] MEM0_wstrb,
+   output logic  MEM0_ready,
+   output logic [31:0] MEM1_rdata,
+   output logic  MEM1_re,
+   output logic  MEM1_ready,
+   memory_32_32.inward regs
+       );
+    
+       logic  REG0_matchSig;
+   logic [3:0] REG0_wstrb;
+   logic  REG0_RE;
+   logic  REG0_WE;
+   logic [31:0] REG0_d;
+   logic  REG1_matchSig;
+   logic  REG1_RE;
+   logic  REG2_matchSig;
+   logic [3:0] REG2_wstrb;
+   logic  REG2_RE;
+   logic  REG2_WE;
+   logic  MEM0_matchSig;
+   logic  MEM0_Nmatch;
+   logic [31:0] MEM0_ADDR;
+   logic  MEM0_RE;
+   logic  MEM0_WE;
+   logic  MEM1_matchSig;
+   logic  MEM1_RE;
+   logic [31:0] MEM1_ADDR;
+    
+    assign REG0_matchSig = regs.ADDR == 0;
+assign REG0_RE = REG0_matchSig && regs.RE;
+assign REG0_WE = REG0_matchSig && regs.WE;
+assign REG0_wstrb = regs.WSTRB;
+assign REG0_d = regs.DATA_WR & REG0_wstrb;
+assign REG1_matchSig = regs.ADDR == 4;
+assign REG1_RE = REG1_matchSig && regs.RE;
+assign REG2_matchSig = regs.ADDR == 8;
+assign REG2_RE = REG2_matchSig && regs.RE;
+assign REG2_WE = REG2_matchSig && regs.WE;
+assign REG2_wstrb = regs.WSTRB;
+assign MEM0_matchSig = (regs.ADDR >= 32) && (regs.ADDR <= (63));
+assign MEM0_Nmatch = regs.ADDR & 4'b1100 == 32;
+assign MEM0_RE = MEM0_matchSig && regs.RE;
+assign MEM0_WE = MEM0_matchSig && regs.WE;
+assign MEM0_ADDR = regs.ADDR;
+assign MEM1_matchSig = (regs.ADDR >= 64) && (regs.ADDR <= (95));
+assign MEM1_RE = MEM1_matchSig && regs.RE;
+assign MEM1_ADDR = regs.ADDR;
+
+  always @(regs.ADDR or regs.RE)
+    if(regs.RE == 1) begin
+      /* verilator lint_off CASEX */
+      casex (regs.ADDR)
+        8'b00000000: begin
+            regs.DATA_RD <= REG0;
+            regs.READY <= 1'b1;
+        end
+     8'b00000100: begin
+            regs.DATA_RD <= REG1;
+            regs.READY <= 1'b1;
+        end
+     8'b00001000: begin
+            regs.DATA_RD <= {REG2_field1, REG2_field0};
+            regs.READY <= 1'b1;
+        end
+     8'b001XXXXX: begin
+            regs.DATA_RD <= MEM0_wdata;
+            regs.READY <= MEM0_ready;
+        end
+     8'b01XXXXXX: begin
+            regs.DATA_RD <= MEM1_rdata;
+            regs.READY <= MEM1_ready;
+        end
+      default: regs.DATA_RD <= 0;
+    endcase
+  end
+
+    
+
+    
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG0 <= 32'h0;
+  end
+  else if(REG0_WE)
+  begin
+  REG0 <= regs.DATA_WR;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG2_field0 <= 16'h10;
+  end
+  else if(REG2_WE && REG2_wstrb)
+  begin
+  REG2_field0 <= regs.DATA_WR[15:0];
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    REG2_field1 <= 16'h20;
+  end
+  else if(REG2_WE && REG2_wstrb)
+  begin
+  REG2_field1 <= regs.DATA_WR[31:16];
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_ready <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_ready <= regs.READY;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_wdata <= 32'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_wdata <= regs.DATA_WR;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_re <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_re <= MEM0_RE;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_we <= 1'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_we <= MEM0_WE;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM0_wstrb <= 32'h0;
+  end
+  else if(MEM0_WE)
+  begin
+  MEM0_wstrb <= 1;
+  end
+  
+  
+     always_ff @( posedge clk  or negedge rst_b )
+  
+       if(!rst_b)
+  begin
+    MEM1_ready <= 1'h0;
+  end
+  else if(regs.WE)
+  begin
+  MEM1_ready <= regs.READY;
+  end
+  
+  
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    
+            
+    /* verilator lint_off WIDTH */        
+    module tb_testRegBlock 
+       (
+       input logic  clk,
+   input logic  rst_b
+       );
+    
+       memory_32_32 regs();
+   logic [31:0] addr;
+   logic  we;
+   logic  re;
+   logic [31:0] wdata;
+   logic [31:0] rdata;
+   logic  ready;
+   logic [31:0] REG0;
+   logic signed [15:0] REG1;
+   logic [15:0] REG2_field0;
+   logic [15:0] REG2_field1;
+   logic [31:0] MEM0_rdata;
+   logic  MEM0_re;
+   logic  MEM0_we;
+   logic [31:0] MEM0_wdata;
+   logic [31:0] MEM0_wstrb;
+   logic  MEM0_ready;
+   logic [31:0] MEM1_rdata;
+   logic  MEM1_re;
+   logic  MEM1_ready;
+    
+    
+    logic [15:0] count;
+
+    always @(posedge clk or negedge rst_b) begin
+      if (!rst_b) begin
+         count <= 'd0;
+      end else begin
+         count <= count + 1'b1;
+
+         case (count)
+            'd0: begin
+               regs.ADDR <= 32'h00000000;
+               regs.DATA_WR <= 32'h12345678;
+               regs.WE <= 1;
+            end
+            'd1: begin
+               regs.WE <= 0;
+               regs.RE <= 1;
+            end
+            'd2: begin
+               regs.RE <= 0;
+            end
+            'd3: begin
+               regs.ADDR <= 32'h00000008;
+               regs.DATA_WR <= 32'h87654321;
+               regs.WE <= 1;
+            end
+            'd4: begin
+               regs.WE <= 0;
+               regs.RE <= 1;
+            end
+            'd5: begin
+               regs.RE <= 0;
+            end
+            'd6: begin
+               regs.ADDR <= 32'h00000020;
+               regs.DATA_WR <= 32'hAABBCCDD;
+               regs.WE <= 1;
+            end
+            'd7: begin
+               regs.WE <= 0;
+               MEM0_rdata <= 32'hAABBCCDD;
+               regs.RE <= 1;
+            end
+            'd8: begin
+               regs.RE <= 0;
+            end
+            'd9: begin
+               // End of test
+               $finish;
+            end
+            default: ;
+         endcase
+      end
+    end
+
+
+    
+      ram_32x32 ram_inst
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .addr(addr),
+        .we(we),
+        .re(re),
+        .wdata(wdata),
+        .rdata(rdata),
+        .ready(ready)
+      );
+  
+      rom_32x32 rom_inst
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .addr(addr),
+        .re(re),
+        .rdata(rdata),
+        .ready(ready)
+      );
+  
+      testRegBlock dut
+      (
+          .clk(clk),
+        .rst_b(rst_b),
+        .REG0(REG0),
+        .REG1(REG1),
+        .REG2_field0(REG2_field0),
+        .REG2_field1(REG2_field1),
+        .MEM0_rdata(MEM0_rdata),
+        .MEM0_re(MEM0_re),
+        .MEM0_we(MEM0_we),
+        .MEM0_wdata(MEM0_wdata),
+        .MEM0_wstrb(MEM0_wstrb),
+        .MEM0_ready(MEM0_ready),
+        .MEM1_rdata(MEM1_rdata),
+        .MEM1_re(MEM1_re),
+        .MEM1_ready(MEM1_ready),
+        .regs(regs)
+      );
+  
+
+    
+    
+    endmodule
+    /* verilator lint_on WIDTH */        
+    


### PR DESCRIPTION
Extends the register toolchain with two new capabilities:

- RWU (Read-Write-Update) access type: allows hardware to update register fields directly alongside APB4 software access
- Hardware Update registers: registers whose values can be driven externally by hardware signals (e.g. hardware pointers, status fields), with corresponding hw_update / hw_update_value ports generated automatically
Includes a gold reference example (sv-examples/gold/Hard_Update2.0.*) demonstrating the full output