### PR TITLE
Body formatting spike

### DIFF
--- a/claude-info/body-formatting-spike-implementation-plan.md
+++ b/claude-info/body-formatting-spike-implementation-plan.md
@@ -1,0 +1,193 @@
+# TSSV Body Formatting Spike Implementation Plan
+
+> Status: Draft
+> Depends on: `claude-info/body-formatting-spike-spec.md`
+
+## Objective
+
+Implement the spike in a low-risk sequence:
+
+1. Add `addBody()` API for symmetric body construction.
+2. Integrate Verible CLI formatting (Linux x86_64 and macOS ARM64 first).
+3. Preserve backward compatibility with existing `this.body += ...` usage.
+4. Convert one representative module (FIR) to validate ergonomics.
+
+## Phase 0: Configuration Model
+
+### Files
+
+- `ts/src/core/Base.ts`
+- `ts/src/core/TSSVLib.ts` (if re-export updates are needed)
+- optional new: `ts/src/core/FormatterConfig.ts`
+
+### Tasks
+
+1. Define a formatter config type in core:
+   - `engine: 'verible' | 'internal' | 'off'`
+   - `veriblePath?: string`
+   - `veribleFlags?: string[]`
+   - `failOnFormatError?: boolean`
+   - `formatTimeoutMs?: number`
+2. Add module-level default formatter config (static/global) with safe defaults.
+3. Add API to override config per process (or per module if desired):
+   - `Module.setFormatterConfig(...)`
+
+### Acceptance checks
+
+- TypeScript compile passes.
+- Existing module generation unchanged with default `engine='off'` (if staged) or
+  deterministic behavior with chosen default.
+
+## Phase 1: addBody API and Internal Normalizer
+
+### Files
+
+- `ts/src/core/Base.ts`
+- optional new: `ts/src/core/svText.ts`
+
+### Tasks
+
+1. Add method:
+   - `addBody(body: string, opts?)`
+   - `addBodyLine(line: string)` (optional convenience)
+2. Implement relative-indent normalization utility:
+   - trim optional leading/trailing blank lines
+   - compute minimum left indent on non-empty lines
+   - strip common indent
+   - ensure trailing newline
+3. Route all new body insertion through `addBody()`.
+4. Keep `this.body` field and existing append behavior functional.
+
+### Acceptance checks
+
+- Unit test: mixed indentation snippet normalizes as expected.
+- Unit test: `indentMode='verbatim'` preserves indentation.
+- Existing tests/scripts still generate valid SV.
+
+## Phase 2: Verible Runner Integration
+
+### Files
+
+- new: `ts/src/tools/formatters/verible.ts`
+- optional new: `ts/src/tools/formatters/process.ts`
+- `ts/src/core/Base.ts`
+
+### Tasks
+
+1. Implement process wrapper using `node:child_process` spawn.
+2. Feed generated SV via stdin, capture stdout/stderr.
+3. Add timeout handling and robust non-zero exit diagnostics.
+4. Implement fallback policy:
+   - if Verible missing/fails and `failOnFormatError=false` -> internal fallback + warning
+   - if `failOnFormatError=true` -> throw with diagnostic context
+
+### Acceptance checks
+
+- Integration test for successful format invocation.
+- Integration test for missing binary path fallback behavior.
+- Integration test for timeout path.
+
+## Phase 3: Verible Binary Acquisition Workflow
+
+### Files
+
+- new script: `scripts/install-verible.sh`
+- optional TS wrapper: `ts/src/tools/verible_install.ts`
+- docs update location: `README.md` or `claude-info/setup.md`
+
+### Tasks
+
+1. Add install script supporting:
+   - Linux x86_64 -> `verible-<tag>-linux-static-x86_64.tar.gz`
+   - macOS ARM64 -> `verible-<tag>-macOS.tar.gz`
+2. Verify archive checksum (SHA-256).
+3. Extract `verible-verilog-format` into deterministic local path.
+4. Document environment variable override for binary path.
+
+### Acceptance checks
+
+- Script works on supported target platforms.
+- Installed binary is executable and discoverable by formatter runner.
+
+## Phase 4: writeSystemVerilog Hook
+
+### Files
+
+- `ts/src/core/Base.ts`
+
+### Tasks
+
+1. After assembling full Verilog text, pass through formatting pipeline:
+   - if `engine='verible'`: run Verible
+   - if `engine='internal'`: run internal normalizer
+   - if `engine='off'`: return raw assembled text
+2. Ensure formatted result is returned by `writeSystemVerilog()`.
+3. Keep failure behavior configurable via `failOnFormatError`.
+
+### Acceptance checks
+
+- Golden output snapshots stable under pinned formatter settings.
+- Verilator lint still passes on generated examples.
+
+## Phase 5: Pilot Conversion (FIR)
+
+### Files
+
+- `ts/src/modules/FIR/FIR.ts`
+
+### Tasks
+
+1. Replace direct `this.body += ...` snippets with `this.addBody(...)` where
+   practical.
+2. Keep existing behavior identical.
+3. Confirm generated `sv-examples/FIR/...` output remains semantically
+   equivalent.
+
+### Acceptance checks
+
+- `npx tsc` succeeds.
+- FIR test script runs and emits valid SV.
+- Verilator lint on generated FIR SV still passes.
+
+## Phase 6: Guardrails and Cleanup
+
+### Files
+
+- `README.md` (or docs note)
+- optional lint policy (if desired)
+
+### Tasks
+
+1. Document preferred usage:
+   - Use `addBody()` for raw SV snippets
+   - Avoid new direct `this.body +=` call sites
+2. Optionally add a grep-based CI check warning on new direct body appends.
+3. Defer broad call-site migration until spike review concludes.
+
+### Acceptance checks
+
+- Contributor guidance is clear and discoverable.
+- No forced large refactor in initial spike.
+
+## Suggested Execution Order
+
+1. Phase 1 (addBody + normalizer)
+2. Phase 2 (Verible runner)
+3. Phase 4 (writeSystemVerilog hook)
+4. Phase 5 (FIR pilot)
+5. Phase 3 + 6 (installer/docs/guardrails)
+
+Reasoning:
+
+- Establish core API and behavior first.
+- Add external dependency integration second.
+- Wire into main generation path only after fallback behavior is solid.
+- Validate ergonomics in one real module before broad rollout.
+
+## Definition of Done (Spike)
+
+- `addBody()` is available and used in at least one production module.
+- Verible formatting works on Linux x86_64 and macOS ARM64.
+- Missing/failed formatter cases are handled deterministically.
+- Generated SV readability improves without semantic regressions.
+- Existing projects continue to function without mandatory migration.

--- a/claude-info/body-formatting-spike-spec.md
+++ b/claude-info/body-formatting-spike-spec.md
@@ -1,0 +1,310 @@
+# TSSV Body Construction and Formatting Spike Spec
+
+> Status: Draft
+> Scope: exploratory API and implementation spike only
+
+## Purpose
+
+This document proposes a second spike to improve raw body text handling in TSSV.
+Today, many call sites append SystemVerilog snippets with direct string
+concatenation (`this.body += ...`). The spike introduces a symmetric
+`addBody()` API and a formatting pipeline that normalizes indentation in the
+final generated SystemVerilog.
+
+The goal is to reduce author friction and style drift while keeping emitted HDL
+readable and predictable.
+
+## Goals
+
+- Add `addBody()` to make custom text insertion consistent with other `add*()`
+  construction methods.
+- Remove the burden on authors to manually align global indentation levels.
+- Normalize indentation as a post-processing step before returning generated
+  SystemVerilog.
+- Integrate `verible-verilog-format` as the default post-processing formatter
+  from the first spike.
+- Support Verible binary usage on Linux x86_64 and macOS ARM64 initially.
+- Keep backward compatibility with existing `this.body += ...` usage during the
+  spike period.
+- Keep behavior deterministic (same input text, same output text).
+
+## Non-goals
+
+- Build an in-house full SystemVerilog parser/formatter in the first spike.
+- Reorder statements or rewrite logic semantics.
+- Auto-refactor existing modules in this spike.
+- Perfectly format every possible raw snippet edge case in v1.
+- Support all host OS/architectures in the first version.
+
+## Problem Summary
+
+Current pain points:
+
+- Raw body text is appended ad hoc across the codebase.
+- Callers must remember indentation style for each snippet.
+- Mixed indentation quality leaks into final emitted `.sv` text.
+- The API is asymmetric (`addSignal`, `addRegister`, etc. vs raw `body +=`).
+
+## Proposed API
+
+### Core method
+
+```typescript
+addBody (
+  body: string,
+  opts?: {
+    indentMode?: 'relative' | 'verbatim'
+    trimLeadingBlankLines?: boolean
+    trimTrailingBlankLines?: boolean
+    ensureTrailingNewline?: boolean
+  }
+): void
+```
+
+Behavior:
+
+- `indentMode: 'relative'` (default):
+  - Compute minimum leading indentation across non-empty lines.
+  - Remove that common indent from all lines.
+  - Store the snippet as logical body content; global module indentation is
+    applied later in generation.
+- `indentMode: 'verbatim'`:
+  - Keep original snippet indentation exactly (except optional trimming/newline
+    policy).
+
+Defaults:
+
+- `indentMode = 'relative'`
+- `trimLeadingBlankLines = true`
+- `trimTrailingBlankLines = true`
+- `ensureTrailingNewline = true`
+
+### Optional helper for line-oriented use
+
+```typescript
+addBodyLine (line: string): void
+```
+
+Equivalent to `addBody(line + '\n', { indentMode: 'relative' })`.
+
+## Authoring Examples
+
+### Before
+
+```typescript
+this.body += `   assign en = m_axis.TREADY || !valid_pipe_1;\n`
+this.body += `   assign s_axis.TREADY = en;\n`
+this.body += `   assign data_in = $signed(s_axis.TDATA[${params.inWidth - 1}:0]);\n`
+```
+
+### After
+
+```typescript
+this.addBody(`
+assign en = m_axis.TREADY || !valid_pipe_1;
+assign s_axis.TREADY = en;
+assign data_in = $signed(s_axis.TDATA[${params.inWidth - 1}:0]);
+`)
+```
+
+The author only needs local self-consistency.
+Global indentation is normalized at generation time.
+
+### Mixed local indentation accepted
+
+```typescript
+this.addBody(`
+    if (valid_pipe_1) begin
+  m_axis.TVALID = 1'b1;
+        end
+`)
+```
+
+Relative normalization should preserve block structure while removing accidental
+left margin drift.
+
+## Generation and Formatting Pipeline
+
+Recommended flow inside `writeSystemVerilog()`:
+
+1. Collect generated sections (interfaces, module header, signals, body,
+   generated register/submodule blocks).
+2. Normalize body snippet indentation (if not already normalized on insert).
+3. Apply global indentation policy for module interior sections.
+4. Run Verible formatter as a post-processing step.
+5. If Verible is unavailable or fails, apply deterministic internal fallback
+   normalization and emit a warning (unless configured to fail hard).
+6. Return final text.
+
+### Indentation policy
+
+- Module interior base indent: 2 or 3 spaces (reuse current style to minimize
+  diff churn).
+- Nested block indent increment: +2 spaces.
+- Do not change token-level spacing in v1; only line-leading whitespace.
+
+## Verible Integration Plan
+
+### Initial platform scope
+
+- Linux x86_64
+- macOS ARM64
+
+Initial release asset patterns to target:
+
+- `verible-<tag>-linux-static-x86_64.tar.gz`
+- `verible-<tag>-macOS.tar.gz`
+
+### Binary acquisition and installation
+
+Proposed strategy:
+
+1. Pin a tested Verible release tag in TSSV config.
+2. Download matching release archive from
+   `https://github.com/chipsalliance/verible/releases`.
+3. Verify SHA-256 checksum against the published release checksum.
+4. Extract `verible-verilog-format` into a local tools cache
+   (for example `third-party/verible/bin/` or user cache directory).
+5. Mark executable (`chmod +x`) on Unix hosts.
+
+Notes:
+
+- Do not rely on `PATH` only; allow explicit binary path configuration.
+- Keep download/install outside hot generation paths.
+
+### Formatter invocation contract
+
+Use Node.js process spawning (`node:child_process`) and communicate via stdin:
+
+```text
+spawn(verible-verilog-format, [flags...])
+stdin  <- generated SystemVerilog text
+stdout -> formatted SystemVerilog text
+stderr -> diagnostics
+```
+
+Recommended defaults:
+
+- `--indentation_spaces=2` (or project-selected value)
+- `--inplace=false` behavior by using stdin/stdout mode
+- Timeout guard for stalled processes
+
+### Configuration knobs
+
+```typescript
+type FormatterConfig = {
+  engine: 'verible' | 'internal' | 'off'
+  veriblePath?: string
+  veribleFlags?: string[]
+  failOnFormatError?: boolean
+  formatTimeoutMs?: number
+}
+```
+
+Default for spike: `engine = 'verible'`.
+
+Fallback behavior:
+
+- If `engine='verible'` and binary missing/fails:
+  - if `failOnFormatError=true`: throw
+  - else: fallback to internal indentation normalizer and warn
+
+### Error handling and diagnostics
+
+- Include formatter command, exit code, and stderr in error messages.
+- Truncate diagnostic payloads only when very large; keep actionable context.
+- Preserve unformatted output when fallback path is selected.
+
+## Internal Representation
+
+Two viable approaches:
+
+### Option A: Keep `body` string, normalize on insert
+
+- `addBody()` appends normalized snippet to existing `body` string.
+- Minimal invasive change.
+- Easy backward compatibility with direct `this.body += ...`.
+
+### Option B: Store body chunks
+
+```typescript
+private bodyChunks: Array<{ text: string, mode: 'relative' | 'verbatim' }>
+```
+
+- `addBody()` pushes structured chunks.
+- Final assembly normalizes/joins chunks before emit.
+- Better long-term extensibility (source mapping, debug, section tagging).
+
+Recommendation for spike: start with Option A for speed.
+
+## Backward Compatibility Strategy
+
+- Keep `body` field working as-is for existing modules.
+- Introduce `addBody()` and use it in new/updated modules.
+- Optionally add a lint rule or grep check later to discourage new direct
+  `this.body +=` usage once API is validated.
+
+## Interaction with Existing APIs
+
+- `addAssign()` remains preferred where it works.
+- `addBody()` is for cases where raw text is required (e.g. interface member
+  assigns, one-off constructs not covered by current helpers).
+- Existing `addCombAlways`/`addSequentialAlways` continue to emit into body.
+
+## Internal Fallback Formatter
+
+Even with Verible as the default, keep a lightweight internal indentation
+normalizer as a deterministic fallback path.
+
+Fallback responsibilities:
+
+- Normalize line-leading whitespace.
+- Preserve text and statement order.
+- Avoid token-level rewrites.
+
+This fallback is primarily for resilience, unsupported host setups, and
+diagnostic isolation.
+
+## Risks and Mitigations
+
+1. Risk: naive indent normalization can break multiline strings or comments.
+   Mitigation: restrict v1 to leading whitespace normalization only; add focused
+   tests for comments and string literals.
+
+2. Risk: mixed manual + generated body sections produce inconsistent style.
+   Mitigation: normalize all body content in one pass before final emit.
+
+3. Risk: large diffs from formatting changes.
+   Mitigation: keep indentation defaults aligned with current style and avoid
+   token reformatting in v1.
+
+## Validation Plan
+
+1. Unit-level checks for `addBody()` normalization behavior.
+2. Golden output comparison on a small module set before/after converting call
+   sites.
+3. Verible integration tests on Linux x86_64 and macOS ARM64:
+  - download/extract path
+  - process spawn success
+  - deterministic formatted output
+4. Confirm generated SV compiles/lints with existing Verilator flow.
+5. Run TypeScript compile and lint to ensure no API regressions.
+
+## Recommended First Spike Scope
+
+Implement only the minimum needed to validate the idea:
+
+1. Add `addBody()` to core module API.
+2. Add indentation normalization utility.
+3. Integrate Verible CLI formatting with configuration and fallback behavior.
+4. Route final body text through normalization + formatter in generation.
+5. Convert one representative module (for example FIR) from direct `body +=`
+   snippets to `addBody()`.
+
+Success criteria:
+
+- Authors can write body snippets without managing global indentation.
+- Generated SV indentation is consistent across modules.
+- Verible formatting works on Linux x86_64 and macOS ARM64.
+- Existing modules continue to work unchanged.
+- No meaningful regression in compile/lint flow.

--- a/claude-info/setup.md
+++ b/claude-info/setup.md
@@ -24,7 +24,52 @@ Install the **Claude Code** extension by Anthropic from the VS Code Extensions m
 
 ---
 
-## 3. Initialize Claude in the TSSV Directory
+## 3. Install Verible (optional — required for `engine: 'verible'` formatting)
+
+Verible provides the `verible-verilog-format` binary used by TSSV's body formatter.
+
+**macOS ARM64**
+
+Verible is distributed via a custom Homebrew tap. Make sure your Xcode Command Line Tools are up to date first (`xcode-select --install`), then:
+
+```bash
+brew tap chipsalliance/verible
+brew install verible
+```
+
+Verify the install:
+
+```bash
+verible-verilog-format --version
+```
+
+Expected output (version may differ):
+
+```
+Version v0.0-3946-g851d3ff4
+Commit-Timestamp        2025-02-17T07:27:44Z
+Built   2025-02-17T07:27:44Z
+```
+
+**Linux**
+
+Download the pre-built binary for your architecture from the [Verible GitHub releases page](https://github.com/chipsalliance/verible/releases) and place `verible-verilog-format` somewhere on your `PATH`.
+
+**Custom binary path**
+
+If the binary is not on `PATH`, pass its location via `FormatterConfig`:
+
+```ts
+Module.setFormatterConfig({
+  engine: 'verible',
+  veriblePath: '/path/to/verible-verilog-format'
+})
+```
+This path should be common for all users to prevent errors.
+
+---
+
+## 4. Initialize Claude in the TSSV Directory
 
 Open the TSSV directory in VS Code, then run the `/init` command. Claude will analyze the codebase and generate a `CLAUDE.md` file at the repo root.
 

--- a/out/src/core/Base.d.ts
+++ b/out/src/core/Base.d.ts
@@ -276,28 +276,39 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
     /**
      * Append a raw SystemVerilog snippet to this module's body.
      *
-     * By default (`indentMode: 'normalize'`), the snippet is normalized before
+     * By default (`indentMode: 'relative'`), the snippet is normalized before
      * being appended:
      * - Leading and trailing blank lines are removed.
-     * - The minimum indentation shared by all non-empty lines is stripped.
+     * - The minimum indentation shared by all non-empty lines is stripped,
+     *   so indentation is computed relative to the snippet's own left margin.
      * - Three spaces of indentation are added to every line so the result sits
      *   correctly inside the generated `module … endmodule` block.
      * - A single trailing newline is guaranteed.
      *
      * This makes it safe to pass indented template literals directly from
-     * TypeScript without worrying about the surrounding indentation level:
+     * TypeScript without worrying about the surrounding indentation level.
      *
-     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
-     * whitespace processing. Use this when the snippet is already correctly
-     * formatted or when preserving exact spacing is required.
+     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, skipping
+     * the indent stripping and re-indentation. The trim and newline options still
+     * apply in verbatim mode.
      *
      * @param body - SystemVerilog text to append.
      * @param opts - Optional settings.
-     * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
-     *   `'verbatim'` appends without modification.
+     * @param opts.indentMode - `'relative'` (default) strips and re-indents
+     *   relative to the snippet's own minimum indent; `'verbatim'` appends
+     *   without modifying indentation.
+     * @param opts.trimLeadingBlankLines - Remove blank lines at the start of the
+     *   snippet before processing. Defaults to `true`.
+     * @param opts.trimTrailingBlankLines - Remove blank lines at the end of the
+     *   snippet before processing. Defaults to `true`.
+     * @param opts.ensureTrailingNewline - Guarantee the appended text ends with
+     *   a newline. Defaults to `true`.
      */
     addBody(body: string, opts?: {
-        indentMode?: 'normalize' | 'verbatim';
+        indentMode?: 'relative' | 'verbatim';
+        trimLeadingBlankLines?: boolean;
+        trimTrailingBlankLines?: boolean;
+        ensureTrailingNewline?: boolean;
     }): void;
     /**
      * Append a single pre-formatted SystemVerilog line to this module's body.

--- a/out/src/core/Base.d.ts
+++ b/out/src/core/Base.d.ts
@@ -73,6 +73,13 @@ interface OperationIO {
     b: string | Sig | bigint;
     result?: string | Sig;
 }
+export interface FormatterConfig {
+    engine: 'verible' | 'internal' | 'off';
+    veriblePath?: string;
+    veribleFlags?: string[];
+    failOnFormatError?: boolean;
+    formatTimeoutMs?: number;
+}
 declare enum BinaryOp {
     MULTIPLY = "*",
     ADD = "+",
@@ -108,6 +115,7 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
     readonly name: string;
     protected params: P;
     protected IOs: IO;
+    protected static formatterConfig: FormatterConfig;
     protected signals: Signals;
     protected submodules: Record<string, {
         module: Module;
@@ -123,6 +131,7 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
        */
     constructor(params?: P, IOs?: IO, signals?: {}, body?: string);
     setVerilogParameter(param: string): void;
+    static setFormatterConfig(config: FormatterConfig): void;
     protected bindingRules: {
         input: string[];
         output: string[];
@@ -265,6 +274,43 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
         default?: string | Sig | Expr;
     }): Sig;
     /**
+     * Append a raw SystemVerilog snippet to this module's body.
+     *
+     * By default (`indentMode: 'normalize'`), the snippet is normalized before
+     * being appended:
+     * - Leading and trailing blank lines are removed.
+     * - The minimum indentation shared by all non-empty lines is stripped.
+     * - Three spaces of indentation are added to every line so the result sits
+     *   correctly inside the generated `module … endmodule` block.
+     * - A single trailing newline is guaranteed.
+     *
+     * This makes it safe to pass indented template literals directly from
+     * TypeScript without worrying about the surrounding indentation level:
+     *
+     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
+     * whitespace processing. Use this when the snippet is already correctly
+     * formatted or when preserving exact spacing is required.
+     *
+     * @param body - SystemVerilog text to append.
+     * @param opts - Optional settings.
+     * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
+     *   `'verbatim'` appends without modification.
+     */
+    addBody(body: string, opts?: {
+        indentMode?: 'normalize' | 'verbatim';
+    }): void;
+    /**
+     * Append a single pre-formatted SystemVerilog line to this module's body.
+     *
+     * The line is appended verbatim with a trailing newline added. No indentation
+     * normalization is performed — the caller is responsible for any leading
+     * whitespace. Use {@link addBody} when passing multi-line template literals
+     * that benefit from automatic indent stripping.
+     *
+     * @param line - A single line of SystemVerilog text (no trailing newline needed).
+     */
+    addBodyLine(line: string): void;
+    /**
        * print some debug information to the console
        */
     debug(): void;
@@ -290,6 +336,7 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
        * @returns string containing the generated SystemVerilog code for this module
        */
     writeSystemVerilog(): string;
+    private applyFormatter;
     private _writeSystemVerilog;
     protected body: string;
     protected registerBlocks: Record<string, Record<string, Record<string, Record<string, {

--- a/out/src/core/Base.js
+++ b/out/src/core/Base.js
@@ -983,40 +983,52 @@ ${caseAssignments}
     /**
      * Append a raw SystemVerilog snippet to this module's body.
      *
-     * By default (`indentMode: 'normalize'`), the snippet is normalized before
+     * By default (`indentMode: 'relative'`), the snippet is normalized before
      * being appended:
      * - Leading and trailing blank lines are removed.
-     * - The minimum indentation shared by all non-empty lines is stripped.
+     * - The minimum indentation shared by all non-empty lines is stripped,
+     *   so indentation is computed relative to the snippet's own left margin.
      * - Three spaces of indentation are added to every line so the result sits
      *   correctly inside the generated `module … endmodule` block.
      * - A single trailing newline is guaranteed.
      *
      * This makes it safe to pass indented template literals directly from
-     * TypeScript without worrying about the surrounding indentation level:
+     * TypeScript without worrying about the surrounding indentation level.
      *
-     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
-     * whitespace processing. Use this when the snippet is already correctly
-     * formatted or when preserving exact spacing is required.
+     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, skipping
+     * the indent stripping and re-indentation. The trim and newline options still
+     * apply in verbatim mode.
      *
      * @param body - SystemVerilog text to append.
      * @param opts - Optional settings.
-     * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
-     *   `'verbatim'` appends without modification.
+     * @param opts.indentMode - `'relative'` (default) strips and re-indents
+     *   relative to the snippet's own minimum indent; `'verbatim'` appends
+     *   without modifying indentation.
+     * @param opts.trimLeadingBlankLines - Remove blank lines at the start of the
+     *   snippet before processing. Defaults to `true`.
+     * @param opts.trimTrailingBlankLines - Remove blank lines at the end of the
+     *   snippet before processing. Defaults to `true`.
+     * @param opts.ensureTrailingNewline - Guarantee the appended text ends with
+     *   a newline. Defaults to `true`.
      */
     addBody(body, opts) {
-        if (opts?.indentMode === 'verbatim') {
-            this.body += body;
-            return;
-        }
+        const trimLeading = opts?.trimLeadingBlankLines ?? true;
+        const trimTrailing = opts?.trimTrailingBlankLines ?? true;
+        const ensureNewline = opts?.ensureTrailingNewline ?? true;
         const lines = body.split('\n');
-        // trim leading blank lines
-        while (lines.length > 0 && lines[0].trim() === '')
-            lines.shift();
-        // trim trailing blank lines
-        while (lines.length > 0 && lines[lines.length - 1].trim() === '')
-            lines.pop();
+        if (trimLeading)
+            while (lines.length > 0 && lines[0].trim() === '')
+                lines.shift();
+        if (trimTrailing)
+            while (lines.length > 0 && lines[lines.length - 1].trim() === '')
+                lines.pop();
         if (lines.length === 0)
             return;
+        if (opts?.indentMode === 'verbatim') {
+            const result = lines.join('\n');
+            this.body += ensureNewline && !result.endsWith('\n') ? result + '\n' : result;
+            return;
+        }
         // compute minimum left indent across non-empty lines
         const minIndent = lines
             .filter(line => line.trim() !== '')
@@ -1028,7 +1040,7 @@ ${caseAssignments}
         const stripped = lines
             .map(line => line.trim() === '' ? '' : indent + line.slice(minIndent === Infinity ? 0 : minIndent))
             .join('\n');
-        this.body += stripped + '\n';
+        this.body += ensureNewline ? stripped + '\n' : stripped;
     }
     /**
      * Append a single pre-formatted SystemVerilog line to this module's body.

--- a/out/src/core/Base.js
+++ b/out/src/core/Base.js
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { runVerible } from '../tools/formatters/verible.js';
 /**
  * container class of a TSSV signal used to pass signals
  * among add* primtives and submodules to define interconnections
@@ -170,6 +171,9 @@ export class Module {
                 throw Error(`unsupported type of parameter ${param} in setVerilogParameter()`);
             }
         }
+    }
+    static setFormatterConfig(config) {
+        Module.formatterConfig = config;
     }
     /**
        * adds an interface signal bundle
@@ -977,6 +981,69 @@ ${caseAssignments}
         return io.out;
     }
     /**
+     * Append a raw SystemVerilog snippet to this module's body.
+     *
+     * By default (`indentMode: 'normalize'`), the snippet is normalized before
+     * being appended:
+     * - Leading and trailing blank lines are removed.
+     * - The minimum indentation shared by all non-empty lines is stripped.
+     * - Three spaces of indentation are added to every line so the result sits
+     *   correctly inside the generated `module … endmodule` block.
+     * - A single trailing newline is guaranteed.
+     *
+     * This makes it safe to pass indented template literals directly from
+     * TypeScript without worrying about the surrounding indentation level:
+     *
+     * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
+     * whitespace processing. Use this when the snippet is already correctly
+     * formatted or when preserving exact spacing is required.
+     *
+     * @param body - SystemVerilog text to append.
+     * @param opts - Optional settings.
+     * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
+     *   `'verbatim'` appends without modification.
+     */
+    addBody(body, opts) {
+        if (opts?.indentMode === 'verbatim') {
+            this.body += body;
+            return;
+        }
+        const lines = body.split('\n');
+        // trim leading blank lines
+        while (lines.length > 0 && lines[0].trim() === '')
+            lines.shift();
+        // trim trailing blank lines
+        while (lines.length > 0 && lines[lines.length - 1].trim() === '')
+            lines.pop();
+        if (lines.length === 0)
+            return;
+        // compute minimum left indent across non-empty lines
+        const minIndent = lines
+            .filter(line => line.trim() !== '')
+            .reduce((min, line) => {
+            const match = line.match(/^(\s*)/);
+            return Math.min(min, match ? match[1].length : 0);
+        }, Infinity);
+        const indent = '   ';
+        const stripped = lines
+            .map(line => line.trim() === '' ? '' : indent + line.slice(minIndent === Infinity ? 0 : minIndent))
+            .join('\n');
+        this.body += stripped + '\n';
+    }
+    /**
+     * Append a single pre-formatted SystemVerilog line to this module's body.
+     *
+     * The line is appended verbatim with a trailing newline added. No indentation
+     * normalization is performed — the caller is responsible for any leading
+     * whitespace. Use {@link addBody} when passing multi-line template literals
+     * that benefit from automatic indent stripping.
+     *
+     * @param line - A single line of SystemVerilog text (no trailing newline needed).
+     */
+    addBodyLine(line) {
+        this.body += line + '\n';
+    }
+    /**
        * print some debug information to the console
        */
     debug() {
@@ -1068,11 +1135,21 @@ ${caseAssignments}
         }
         Module.svGenDepth++;
         try {
-            return this._writeSystemVerilog();
+            const sv = this._writeSystemVerilog();
+            if (Module.svGenDepth === 1 && Module.formatterConfig.engine !== 'off') {
+                return this.applyFormatter(sv);
+            }
+            return sv;
         }
         finally {
             Module.svGenDepth--;
         }
+    }
+    applyFormatter(sv) {
+        if (Module.formatterConfig.engine === 'verible') {
+            return runVerible(sv, Module.formatterConfig);
+        }
+        return sv;
     }
     _writeSystemVerilog() {
         // assemble TSSVParameters
@@ -1242,26 +1319,26 @@ ${bindingsArray.join(',\n')}
       );
 `;
         }
-        const verilog = `
-${interfacesString}
-${subModulesString}
-
-/* verilator lint_off WIDTH */
+        // returns s with a guaranteed trailing newline, or '' if s is blank
+        const opt = (s) => {
+            if (!s.trim())
+                return '';
+            return s.endsWith('\n') ? s : s + '\n';
+        };
+        const verilog = `${opt(interfacesString)}${opt(subModulesString)}/* verilator lint_off WIDTH */
 module ${this.name} ${paramsString}
    (
 ${IOString}
    );
-${this.formatParametersAsVerilogComment(this.params)}
-${signalString}
-
-${this.body}
-${generatedBody}
+${opt(this.formatParametersAsVerilogComment(this.params))}${opt(signalString)}
+${opt(this.body)}${opt(generatedBody)}
 endmodule
-/* verilator lint_on WIDTH */        
+/* verilator lint_on WIDTH */
 `;
         return verilog;
     }
 }
+Module.formatterConfig = { engine: 'off' };
 Module.printedInterfaces = {};
 Module.svGenDepth = 0;
 export function serialize(obj, indent, bigIntSuffix = 'n') {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs": "typedoc --out docs",
-    "deploy-docs": "gh-pages -d docs"
+    "deploy-docs": "gh-pages -d docs",
+    "check:body": "bash scripts/check-body-appends.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs": "typedoc --out docs",
     "deploy-docs": "gh-pages -d docs",
-    "check:body": "bash scripts/check-body-appends.sh"
+    "check:body": "bash scripts/check-body-appends.sh",
+    "lint:sv": "bash scripts/lint-sv.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-body-appends.sh
+++ b/scripts/check-body-appends.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Warn if module or interface files use direct this.body += instead of this.addBody().
+# Exits 0 always — this is a warning, not a hard failure.
+
+matches=$(grep -rn "this\.body +=" ts/src/modules/ ts/src/interfaces/ 2>/dev/null)
+
+if [ -n "$matches" ]; then
+  echo "WARNING: Direct this.body += found in the following locations."
+  echo "Prefer this.addBody() for new code:"
+  echo ""
+  echo "$matches"
+  echo ""
+  echo "See claude-info/body-formatting-spike-implementation-plan.md for guidance."
+else
+  echo "OK: No direct this.body += found in modules or interfaces."
+fi

--- a/scripts/lint-sv.sh
+++ b/scripts/lint-sv.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run verilator --lint-only on every .sv file under sv-examples/.
+# Exits 0 if all pass, 1 if any fail.
+
+if ! command -v verilator &>/dev/null; then
+  echo "ERROR: verilator not found on PATH"
+  exit 1
+fi
+
+passed=0
+failed=0
+failures=()
+
+while IFS= read -r -d '' file; do
+  if verilator --lint-only "$file" &>/dev/null; then
+    echo "PASS: $file"
+    ((passed++))
+  else
+    echo "FAIL: $file"
+    failures+=("$file")
+    ((failed++))
+  fi
+done < <(find sv-examples -name "*.sv" -print0 | sort -z)
+
+echo ""
+echo "$passed passed, $failed failed"
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo ""
+  echo "Failing files:"
+  for f in "${failures[@]}"; do
+    echo "  $f"
+  done
+  exit 1
+fi

--- a/ts/src/core/Base.ts
+++ b/ts/src/core/Base.ts
@@ -1125,40 +1125,56 @@ ${caseAssignments}
   /**
    * Append a raw SystemVerilog snippet to this module's body.
    *
-   * By default (`indentMode: 'normalize'`), the snippet is normalized before
+   * By default (`indentMode: 'relative'`), the snippet is normalized before
    * being appended:
    * - Leading and trailing blank lines are removed.
-   * - The minimum indentation shared by all non-empty lines is stripped.
+   * - The minimum indentation shared by all non-empty lines is stripped,
+   *   so indentation is computed relative to the snippet's own left margin.
    * - Three spaces of indentation are added to every line so the result sits
    *   correctly inside the generated `module … endmodule` block.
    * - A single trailing newline is guaranteed.
    *
    * This makes it safe to pass indented template literals directly from
-   * TypeScript without worrying about the surrounding indentation level:
+   * TypeScript without worrying about the surrounding indentation level.
    *
-   * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
-   * whitespace processing. Use this when the snippet is already correctly
-   * formatted or when preserving exact spacing is required.
+   * Pass `indentMode: 'verbatim'` to append the string exactly as-is, skipping
+   * the indent stripping and re-indentation. The trim and newline options still
+   * apply in verbatim mode.
    *
    * @param body - SystemVerilog text to append.
    * @param opts - Optional settings.
-   * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
-   *   `'verbatim'` appends without modification.
+   * @param opts.indentMode - `'relative'` (default) strips and re-indents
+   *   relative to the snippet's own minimum indent; `'verbatim'` appends
+   *   without modifying indentation.
+   * @param opts.trimLeadingBlankLines - Remove blank lines at the start of the
+   *   snippet before processing. Defaults to `true`.
+   * @param opts.trimTrailingBlankLines - Remove blank lines at the end of the
+   *   snippet before processing. Defaults to `true`.
+   * @param opts.ensureTrailingNewline - Guarantee the appended text ends with
+   *   a newline. Defaults to `true`.
    */
-  addBody (body: string, opts?: { indentMode?: 'normalize' | 'verbatim' }): void {
-    if (opts?.indentMode === 'verbatim') {
-      this.body += body
-      return
-    }
+  addBody (body: string, opts?: {
+    indentMode?: 'relative' | 'verbatim'
+    trimLeadingBlankLines?: boolean
+    trimTrailingBlankLines?: boolean
+    ensureTrailingNewline?: boolean
+  }): void {
+    const trimLeading = opts?.trimLeadingBlankLines ?? true
+    const trimTrailing = opts?.trimTrailingBlankLines ?? true
+    const ensureNewline = opts?.ensureTrailingNewline ?? true
 
     const lines = body.split('\n')
 
-    // trim leading blank lines
-    while (lines.length > 0 && lines[0].trim() === '') lines.shift()
-    // trim trailing blank lines
-    while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop()
+    if (trimLeading) while (lines.length > 0 && lines[0].trim() === '') lines.shift()
+    if (trimTrailing) while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop()
 
     if (lines.length === 0) return
+
+    if (opts?.indentMode === 'verbatim') {
+      const result = lines.join('\n')
+      this.body += ensureNewline && !result.endsWith('\n') ? result + '\n' : result
+      return
+    }
 
     // compute minimum left indent across non-empty lines
     const minIndent = lines
@@ -1173,7 +1189,7 @@ ${caseAssignments}
       .map(line => line.trim() === '' ? '' : indent + line.slice(minIndent === Infinity ? 0 : minIndent))
       .join('\n')
 
-    this.body += stripped + '\n'
+    this.body += ensureNewline ? stripped + '\n' : stripped
   }
 
   /**

--- a/ts/src/core/Base.ts
+++ b/ts/src/core/Base.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs'
+import { runVerible } from '../tools/formatters/verible.js'
 
 /**
  * IntRange type allows specifify a type that allows a range of integer values
@@ -126,6 +127,14 @@ interface OperationIO {
   result?: string | Sig
 }
 
+export interface FormatterConfig {
+  engine: 'verible' | 'internal' | 'off'
+  veriblePath?: string
+  veribleFlags?: string[]
+  failOnFormatError?: boolean
+  formatTimeoutMs?: number
+}
+
 enum BinaryOp {
   MULTIPLY = '*',
   ADD = '+',
@@ -215,6 +224,7 @@ export class Module<P extends TSSVParameters = TSSVParameters, IO extends IOSign
 
   protected params: P
   protected IOs: IO
+  protected static formatterConfig: FormatterConfig = { engine: 'off' }
   protected signals: Signals
   protected submodules: Record<string, {
     module: Module
@@ -268,6 +278,10 @@ export class Module<P extends TSSVParameters = TSSVParameters, IO extends IOSign
         throw Error(`unsupported type of parameter ${param} in setVerilogParameter()`)
       }
     }
+  }
+
+  static setFormatterConfig (config: FormatterConfig): void {
+    Module.formatterConfig = config
   }
 
   protected bindingRules = {
@@ -1109,6 +1123,74 @@ ${caseAssignments}
   }
 
   /**
+   * Append a raw SystemVerilog snippet to this module's body.
+   *
+   * By default (`indentMode: 'normalize'`), the snippet is normalized before
+   * being appended:
+   * - Leading and trailing blank lines are removed.
+   * - The minimum indentation shared by all non-empty lines is stripped.
+   * - Three spaces of indentation are added to every line so the result sits
+   *   correctly inside the generated `module … endmodule` block.
+   * - A single trailing newline is guaranteed.
+   *
+   * This makes it safe to pass indented template literals directly from
+   * TypeScript without worrying about the surrounding indentation level:
+   *
+   * Pass `indentMode: 'verbatim'` to append the string exactly as-is, with no
+   * whitespace processing. Use this when the snippet is already correctly
+   * formatted or when preserving exact spacing is required.
+   *
+   * @param body - SystemVerilog text to append.
+   * @param opts - Optional settings.
+   * @param opts.indentMode - `'normalize'` (default) strips and re-indents;
+   *   `'verbatim'` appends without modification.
+   */
+  addBody (body: string, opts?: { indentMode?: 'normalize' | 'verbatim' }): void {
+    if (opts?.indentMode === 'verbatim') {
+      this.body += body
+      return
+    }
+
+    const lines = body.split('\n')
+
+    // trim leading blank lines
+    while (lines.length > 0 && lines[0].trim() === '') lines.shift()
+    // trim trailing blank lines
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop()
+
+    if (lines.length === 0) return
+
+    // compute minimum left indent across non-empty lines
+    const minIndent = lines
+      .filter(line => line.trim() !== '')
+      .reduce((min, line) => {
+        const match = line.match(/^(\s*)/)
+        return Math.min(min, match ? match[1].length : 0)
+      }, Infinity)
+
+    const indent = '   '
+    const stripped = lines
+      .map(line => line.trim() === '' ? '' : indent + line.slice(minIndent === Infinity ? 0 : minIndent))
+      .join('\n')
+
+    this.body += stripped + '\n'
+  }
+
+  /**
+   * Append a single pre-formatted SystemVerilog line to this module's body.
+   *
+   * The line is appended verbatim with a trailing newline added. No indentation
+   * normalization is performed — the caller is responsible for any leading
+   * whitespace. Use {@link addBody} when passing multi-line template literals
+   * that benefit from automatic indent stripping.
+   *
+   * @param line - A single line of SystemVerilog text (no trailing newline needed).
+   */
+  addBodyLine (line: string): void {
+    this.body += line + '\n'
+  }
+
+  /**
      * print some debug information to the console
      */
   debug (): void {
@@ -1217,10 +1299,21 @@ ${caseAssignments}
     }
     Module.svGenDepth++
     try {
-      return this._writeSystemVerilog()
+      const sv = this._writeSystemVerilog()
+      if (Module.svGenDepth === 1 && Module.formatterConfig.engine !== 'off') {
+        return this.applyFormatter(sv)
+      }
+      return sv
     } finally {
       Module.svGenDepth--
     }
+  }
+
+  private applyFormatter (sv: string): string {
+    if (Module.formatterConfig.engine === 'verible') {
+      return runVerible(sv, Module.formatterConfig)
+    }
+    return sv
   }
 
   private _writeSystemVerilog (): string {
@@ -1393,23 +1486,22 @@ ${bindingsArray.join(',\n')}
 `
     }
 
-    const verilog: string =
-`
-${interfacesString}
-${subModulesString}
+    // returns s with a guaranteed trailing newline, or '' if s is blank
+    const opt = (s: string): string => {
+      if (!s.trim()) return ''
+      return s.endsWith('\n') ? s : s + '\n'
+    }
 
-/* verilator lint_off WIDTH */
+    const verilog: string =
+`${opt(interfacesString)}${opt(subModulesString)}/* verilator lint_off WIDTH */
 module ${this.name} ${paramsString}
    (
 ${IOString}
    );
-${this.formatParametersAsVerilogComment(this.params)}
-${signalString}
-
-${this.body}
-${generatedBody}
+${opt(this.formatParametersAsVerilogComment(this.params))}${opt(signalString)}
+${opt(this.body)}${opt(generatedBody)}
 endmodule
-/* verilator lint_on WIDTH */        
+/* verilator lint_on WIDTH */
 `
 
     return verilog

--- a/ts/src/modules/FIR/FIR.ts
+++ b/ts/src/modules/FIR/FIR.ts
@@ -114,12 +114,12 @@ export class FIR extends TSSV.Module<FIR_ParamsNorm, FIR_Ports> {
 
     // AXI-to-FIR adapter assigns
     // pipeline advances when output can drain or has no valid data yet
-    this.body += `   assign en = m_axis.TREADY || !valid_pipe_1;\n`
-    // must use this.body directly — addAssign validates out via findSignal, which only
-    // searches IOs and signals; interface sub-signals like s_axis.TREADY are not found there
-    this.body += `   assign s_axis.TREADY = en;\n`
-    // extract signed sample from LSBs of TDATA
-    this.body += `   assign data_in = $signed(s_axis.TDATA[${params.inWidth - 1}:0]);\n`
+    // addAssign cannot be used for interface sub-signals (findSignal only resolves IOs and declared signals)
+    this.addBody(`
+      assign en = m_axis.TREADY || !valid_pipe_1;
+      assign s_axis.TREADY = en;
+      assign data_in = $signed(s_axis.TDATA[${params.inWidth - 1}:0]);
+    `)
 
     // 2-stage valid shift register — tracks which pipeline stages hold real data
     this.addRegister({ d: new TSSV.Expr('s_axis.TVALID'), clk: 'clk', reset: 'rst_b', en: 'en', q: 'valid_pipe_0' })
@@ -191,16 +191,16 @@ export class FIR extends TSSV.Module<FIR_ParamsNorm, FIR_Ports> {
 
     // FIR-to-AXI adapter assigns — all outputs are m_axis interface sub-signals,
     // so addAssign cannot be used (findSignal only resolves IOs and declared signals)
-    this.body += `   assign m_axis.TVALID = valid_pipe_1;\n`
-    // sign-extend data_out to fill the 32-bit TDATA field
-    this.body += `   assign m_axis.TDATA  = {{${32 - params.outWidth}{data_out[${params.outWidth - 1}]}}, data_out};\n`
-    // each sample is its own packet; all byte lanes carry valid data
-    this.body += `   assign m_axis.TLAST   = 1'b1;\n`
-    this.body += `   assign m_axis.TSTRB   = 4'hF;\n`
-    this.body += `   assign m_axis.TKEEP   = 4'hF;\n`
-    this.body += `   assign m_axis.TID     = '0;\n`
-    this.body += `   assign m_axis.TDEST   = '0;\n`
-    this.body += `   assign m_axis.TWAKEUP = 1'b0;\n`
+    this.addBody(`
+      assign m_axis.TVALID = valid_pipe_1;
+      assign m_axis.TDATA  = {{${32 - params.outWidth}{data_out[${params.outWidth - 1}]}}, data_out};
+      assign m_axis.TLAST   = 1'b1;
+      assign m_axis.TSTRB   = 4'hF;
+      assign m_axis.TKEEP   = 4'hF;
+      assign m_axis.TID     = '0;
+      assign m_axis.TDEST   = '0;
+      assign m_axis.TWAKEUP = 1'b0;
+    `)
   }
 }
 

--- a/ts/src/tools/formatters/verible.ts
+++ b/ts/src/tools/formatters/verible.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process'
+
+export interface VeribleOpts {
+  veriblePath?: string
+  veribleFlags?: string[]
+  failOnFormatError?: boolean
+  formatTimeoutMs?: number
+}
+
+export function runVerible (sv: string, opts: VeribleOpts): string {
+  const binary = opts.veriblePath ?? 'verible-verilog-format'
+  const args = [...(opts.veribleFlags ?? []), '-']
+  const timeout = opts.formatTimeoutMs ?? 5000
+
+  const result = spawnSync(binary, args, {
+    input: sv,
+    timeout,
+    encoding: 'utf8'
+  })
+
+  if (result.status === 0 && result.stdout) {
+    return result.stdout
+  }
+
+  const diagnostic = [
+    `verible-verilog-format failed`,
+    `  binary:    ${binary}`,
+    `  exit code: ${result.status ?? '(none)'}`,
+    result.error ? `  error:     ${result.error.message}` : null,
+    result.stderr ? `  stderr:    ${result.stderr.trim()}` : null
+  ].filter(Boolean).join('\n')
+
+  if (opts.failOnFormatError === true) {
+    throw new Error(diagnostic)
+  }
+
+  console.warn(diagnostic)
+  return sv
+}

--- a/ts/test/test_addBody.ts
+++ b/ts/test/test_addBody.ts
@@ -1,0 +1,140 @@
+import { Module } from 'tssv/lib/core/TSSV'
+import { mkdirSync, writeFileSync } from 'fs'
+
+try { mkdirSync('sv-examples/Core/addBody', { recursive: true }) } catch (e) {}
+
+// Expose protected body for assertions
+class TestModule extends Module {
+  getBody (): string { return this.body }
+  setBody (s: string): void { this.body = s }
+}
+
+let passed = 0
+let failed = 0
+
+function check (label: string, actual: string, expected: string): void {
+  if (actual === expected) {
+    console.log(`PASS: ${label}`)
+    passed++
+  } else {
+    console.error(`FAIL: ${label}`)
+    console.error(`  expected: ${JSON.stringify(expected)}`)
+    console.error(`  actual:   ${JSON.stringify(actual)}`)
+    failed++
+  }
+}
+
+// --- Test 1: common indent stripped, leading/trailing blank lines removed ---
+const m1 = new TestModule({ name: 'test_normalize' }, {
+  clk: { direction: 'input', isClock: 'posedge' },
+  out: { direction: 'output', width: 8 },
+  in: { direction: 'input', width: 8 }
+})
+m1.addBody(`
+        always_ff @(posedge clk) begin
+          out <= in;
+        end
+`)
+check(
+  'normalize strips common indent and blank lines',
+  m1.getBody(),
+`   always_ff @(posedge clk) begin
+     out <= in;
+   end
+`
+)
+writeFileSync('sv-examples/Core/addBody/test_normalize.sv', m1.writeSystemVerilog())
+
+// --- Test 2: verbatim preserves indent ---
+const m2 = new TestModule({ name: 'test_verbatim' }, {
+  clk: { direction: 'input', isClock: 'posedge' },
+  out: { direction: 'output', width: 8 },
+  in: { direction: 'input', width: 8 }
+})
+m2.addBody('  assign out = in;\n', { indentMode: 'verbatim' })
+check(
+  'verbatim preserves indentation',
+  m2.getBody(),
+  '  assign out = in;\n'
+)
+writeFileSync('sv-examples/Core/addBody/test_verbatim.sv', m2.writeSystemVerilog())
+
+// --- Test 3: addBodyLine appends with newline ---
+const m3 = new TestModule({ name: 'test_addBodyLine' }, {
+  a: { direction: 'input', width: 8 },
+  b: { direction: 'output', width: 8 }
+})
+m3.addBodyLine('  assign b = a;')
+check(
+  'addBodyLine appends line with trailing newline',
+  m3.getBody(),
+  '  assign b = a;\n'
+)
+writeFileSync('sv-examples/Core/addBody/test_addBodyLine.sv', m3.writeSystemVerilog())
+
+// --- Test 4: addBody normalizes and indents body content ---
+const m4ref = new TestModule({ name: 'test_equiv_ref' }, {
+  clk: { direction: 'input', isClock: 'posedge' },
+  out: { direction: 'output', width: 8 },
+  in: { direction: 'input', width: 8 }
+})
+m4ref.setBody(
+`   always_ff @(posedge clk) begin
+     out <= in;
+   end`)
+const m4 = new TestModule({ name: 'test_equiv_addBody' }, {
+  clk: { direction: 'input', isClock: 'posedge' },
+  out: { direction: 'output', width: 8 },
+  in: { direction: 'input', width: 8 }
+})
+m4.addBody(`
+  always_ff @(posedge clk) begin
+    out <= in;
+  end
+`)
+
+const m4refSV = m4ref.writeSystemVerilog()
+const m4SV = m4.writeSystemVerilog().replace('test_equiv_addBody', 'test_equiv_ref')
+check(
+  'addBody normalizes and indents body content',
+  m4SV,
+  m4refSV
+)
+writeFileSync('sv-examples/Core/addBody/test_equiv_ref.sv', m4ref.writeSystemVerilog())
+writeFileSync('sv-examples/Core/addBody/test_equiv_addBody.sv', m4.writeSystemVerilog())
+
+// --- Test 5: empty addBody call is a no-op ---
+const m5 = new TestModule({ name: 'test_empty' }, {
+  a: { direction: 'input', width: 1 },
+  b: { direction: 'output', width: 1 }
+})
+m5.addBody('   \n\n   ')
+check(
+  'addBody with only whitespace/blank lines is a no-op',
+  m5.getBody(),
+  ''
+)
+writeFileSync('sv-examples/Core/addBody/test_empty.sv', m5.writeSystemVerilog())
+
+// --- Test 6: default engine is off (formatterConfig does not alter output) ---
+const m6 = new TestModule({ name: 'test_engine_off' }, {
+  clk: { direction: 'input', isClock: 'posedge' },
+  out: { direction: 'output', width: 4 },
+  in: { direction: 'input', width: 4 }
+})
+m6.addBody('always_ff @(posedge clk) begin\n  out <= in;\nend\n', { indentMode: 'verbatim' })
+const sv = m6.writeSystemVerilog()
+const hasModule = sv.includes('module test_engine_off')
+const hasEndmodule = sv.includes('endmodule')
+if (hasModule && hasEndmodule) {
+  console.log('PASS: writeSystemVerilog produces valid SV with default engine=off')
+  passed++
+} else {
+  console.error('FAIL: writeSystemVerilog output malformed with default engine=off')
+  console.error(sv)
+  failed++
+}
+writeFileSync('sv-examples/Core/addBody/test_engine_off.sv', sv)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/ts/test/test_verible.ts
+++ b/ts/test/test_verible.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'fs'
+import { runVerible } from 'tssv/lib/tools/formatters/verible'
+
+try { mkdirSync('sv-examples/Core/verible', { recursive: true }) } catch (e) {}
+
+let passed = 0
+let failed = 0
+
+function check (label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`PASS: ${label}`)
+    passed++
+  } else {
+    console.error(`FAIL: ${label}${detail ? `\n  ${detail}` : ''}`)
+    failed++
+  }
+}
+
+function skip (label: string): void {
+  console.log(`SKIP: ${label}`)
+}
+
+const SAMPLE_SV =
+`module sample(input logic clk, output logic [7:0] out);
+  always_ff @(posedge clk) begin
+    out <= 8'd0;
+  end
+endmodule
+`
+
+// Probe for Verible once
+const probe = spawnSync('verible-verilog-format', ['--version'], { encoding: 'utf8' })
+const veribleAvailable = probe.status === 0
+
+// --- Test 1: successful format (skipped if Verible not installed) ---
+if (veribleAvailable) {
+  const result = runVerible(SAMPLE_SV, {})
+  writeFileSync('sv-examples/Core/verible/sample_formatted.sv', result)
+  check(
+    'runVerible returns non-empty formatted SV',
+    result.length > 0 && result.includes('module'),
+    `got: ${JSON.stringify(result.slice(0, 80))}`
+  )
+} else {
+  skip('runVerible successful format (verible-verilog-format not found on PATH)')
+}
+
+// --- Test 2: missing binary, failOnFormatError=false → returns original ---
+const result2 = runVerible(SAMPLE_SV, {
+  veriblePath: '/nonexistent/verible-verilog-format',
+  failOnFormatError: false
+})
+writeFileSync('sv-examples/Core/verible/missing_binary_fallback.sv', result2)
+check(
+  'missing binary with failOnFormatError=false returns original SV',
+  result2 === SAMPLE_SV
+)
+
+// --- Test 3: missing binary, failOnFormatError=true → throws ---
+let threw = false
+try {
+  runVerible(SAMPLE_SV, {
+    veriblePath: '/nonexistent/verible-verilog-format',
+    failOnFormatError: true
+  })
+} catch (e) {
+  threw = true
+}
+check('missing binary with failOnFormatError=true throws', threw)
+
+// --- Test 4: timeout, failOnFormatError=false → returns original ---
+const result4 = runVerible(SAMPLE_SV, {
+  formatTimeoutMs: 1,
+  failOnFormatError: false
+})
+writeFileSync('sv-examples/Core/verible/timeout_fallback.sv', result4)
+check(
+  'timeout with failOnFormatError=false returns original SV',
+  result4 === SAMPLE_SV
+)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
Added functionality to create addBody() calls to add direct system verilog to a TSSV module whthout having to access the Module's internal fields. This addBody call has options for indentation. An addBodyLine has also been added for adding a singular line which is inserted verbatim. The option to use a formatter engine when writing out the system verilog has also been added. The only supported one so far is verible, and is not enabled by default.