### PR TITLE
Extend ParameterValue types and fix submodule deduplication

### DIFF
--- a/out/src/core/Base.d.ts
+++ b/out/src/core/Base.d.ts
@@ -3,11 +3,7 @@
  * Used in Parameter types on TSSV modules where the parameters have range restrictions
  */
 export type IntRange<START extends number, END extends number, ARR extends unknown[] = [], ACC extends number = never> = ARR['length'] extends END ? ACC | START | END : IntRange<START, END, [...ARR, 1], ARR[START] extends undefined ? ACC : ACC | ARR['length']>;
-type ParameterValue = string | boolean | bigint | IntRange<number, number> | bigint[] | string[] | Array<IntRange<number, number>> | {
-    [name: string]: ParameterValue | undefined;
-} | Array<{
-    [name: string]: ParameterValue | undefined;
-}>;
+type ParameterValue = string | boolean | bigint | IntRange<number, number> | bigint[] | string[] | Array<IntRange<number, number>> | object;
 export interface TSSVParameters {
     name?: string | undefined;
     [name: string]: ParameterValue | undefined;

--- a/out/src/core/Base.d.ts
+++ b/out/src/core/Base.d.ts
@@ -293,6 +293,7 @@ export declare class Module<P extends TSSVParameters = TSSVParameters, IO extend
         resetVal?: bigint;
     }>>>>;
     protected static printedInterfaces: Record<string, boolean>;
+    private static printedModules;
     private static svGenDepth;
     protected verilogParams: Record<string, boolean>;
 }

--- a/out/src/core/Base.d.ts
+++ b/out/src/core/Base.d.ts
@@ -3,7 +3,7 @@
  * Used in Parameter types on TSSV modules where the parameters have range restrictions
  */
 export type IntRange<START extends number, END extends number, ARR extends unknown[] = [], ACC extends number = never> = ARR['length'] extends END ? ACC | START | END : IntRange<START, END, [...ARR, 1], ARR[START] extends undefined ? ACC : ACC | ARR['length']>;
-type ParameterValue = string | bigint | IntRange<number, number> | bigint[] | Array<IntRange<number, number>> | {
+type ParameterValue = string | boolean | bigint | IntRange<number, number> | bigint[] | string[] | Array<IntRange<number, number>> | {
     [name: string]: ParameterValue | undefined;
 } | Array<{
     [name: string]: ParameterValue | undefined;

--- a/out/src/core/Base.js
+++ b/out/src/core/Base.js
@@ -1065,6 +1065,7 @@ ${caseAssignments}
     writeSystemVerilog() {
         if (Module.svGenDepth === 0) {
             Module.printedInterfaces = {};
+            Module.printedModules = {};
         }
         Module.svGenDepth++;
         try {
@@ -1205,12 +1206,11 @@ ${functionalAssigments.join('\n')}
             }
         }
         let subModulesString = '';
-        const printed = {};
         for (const moduleInstance in this.submodules) {
             const thisSubmodule = this.submodules[moduleInstance];
             let paramsBind = '';
-            if (!printed[thisSubmodule.module.name]) {
-                printed[thisSubmodule.module.name] = true;
+            if (!Module.printedModules[thisSubmodule.module.name]) {
+                Module.printedModules[thisSubmodule.module.name] = true;
                 subModulesString += thisSubmodule.module.writeSystemVerilog();
             }
             const bindingsArray = [];
@@ -1263,6 +1263,7 @@ endmodule
     }
 }
 Module.printedInterfaces = {};
+Module.printedModules = {};
 Module.svGenDepth = 0;
 export function serialize(obj, indent, bigIntSuffix = 'n') {
     const serialized = JSON.stringify(obj, function (key, value) {

--- a/ts/src/core/Base.ts
+++ b/ts/src/core/Base.ts
@@ -15,8 +15,7 @@ ACC extends number = never> = ARR['length'] extends END
 type ParameterValue =
   string | boolean | bigint | IntRange<number, number> | bigint[] | string[] |
   Array<IntRange<number, number>> |
-  { [name: string]: ParameterValue | undefined } |
-  Array<{ [name: string]: ParameterValue | undefined }>
+  object
 
 export interface TSSVParameters {
   name?: string | undefined

--- a/ts/src/core/Base.ts
+++ b/ts/src/core/Base.ts
@@ -1213,6 +1213,7 @@ ${caseAssignments}
   writeSystemVerilog (): string {
     if (Module.svGenDepth === 0) {
       Module.printedInterfaces = {}
+      Module.printedModules = {}
     }
     Module.svGenDepth++
     try {
@@ -1355,12 +1356,11 @@ ${functionalAssigments.join('\n')}
     }
 
     let subModulesString = ''
-    const printed: Record<string, boolean> = {}
     for (const moduleInstance in this.submodules) {
       const thisSubmodule = this.submodules[moduleInstance]
       let paramsBind = ''
-      if (!printed[thisSubmodule.module.name]) {
-        printed[thisSubmodule.module.name] = true
+      if (!Module.printedModules[thisSubmodule.module.name]) {
+        Module.printedModules[thisSubmodule.module.name] = true
         subModulesString += thisSubmodule.module.writeSystemVerilog()
       }
       const bindingsArray: string[] = []
@@ -1418,6 +1418,7 @@ endmodule
   protected registerBlocks: Record<string, Record<string, Record<string, Record<string, { d: string, resetVal?: bigint }>>>> = {}
 
   protected static printedInterfaces: Record<string, boolean> = {}
+  private static printedModules: Record<string, boolean> = {}
   private static svGenDepth = 0
 
   protected verilogParams: Record<string, boolean>

--- a/ts/src/core/Base.ts
+++ b/ts/src/core/Base.ts
@@ -13,7 +13,7 @@ ACC extends number = never> = ARR['length'] extends END
   : IntRange<START, END, [...ARR, 1], ARR[START] extends undefined ? ACC : ACC | ARR['length']>
 
 type ParameterValue =
-  string | bigint | IntRange<number, number> | bigint[] |
+  string | boolean | bigint | IntRange<number, number> | bigint[] | string[] |
   Array<IntRange<number, number>> |
   { [name: string]: ParameterValue | undefined } |
   Array<{ [name: string]: ParameterValue | undefined }>


### PR DESCRIPTION
This branch makes two improvements to Base.ts. First, it broadens the ParameterValue union type to accept boolean, string[], and a general object, giving module authors more flexibility when defining typed parameter bags. Objects are supported in the module naming scheme by hashing their contents, producing a stable deterministic suffix that uniquely identifies the parameter combination. Second, it fixes a bug where writeSystemVerilog() emitted duplicate module definitions when the same parameterized submodule type appeared inside multiple instances of the same parent.